### PR TITLE
[BE] Member 탈퇴, 삭제, 단일회원조회, 전체회원 페이지조회, 비밀번호 확인 API 구현

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/UYouBooDanApplication.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/UYouBooDanApplication.java
@@ -2,7 +2,9 @@ package TeamBigDipper.UYouBooDan;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class UYouBooDanApplication {
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/auditing/BaseTimeEntity.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/auditing/BaseTimeEntity.java
@@ -31,5 +31,6 @@ public class BaseTimeEntity {
     private LocalDateTime createdAt;
 
     @LastModifiedDate  // 애너테이션으로 자동 적용
+    @Column(name="last_modified_at")
     private LocalDateTime modifiedAt;
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -47,9 +47,9 @@ public class MemberController {
      * @param memberId : 시큐리티 구성 전 임시 Variable
      * @return void
      */
-    @PatchMapping("/edit/{member_id}")
+    @PatchMapping("/edit/{member-id}")
     public ResponseEntity<SingleResDto<String>> patchMember (@RequestBody MemberPatchReqDto memberPatchReqDto,
-                                                             @PathVariable("member_id") Long memberId) {
+                                                             @PathVariable("member-id") Long memberId) {
         memberService.modifyMember(memberPatchReqDto.toEntity(), memberId);
         return new ResponseEntity<>(new SingleResDto<>("Success Patch"), HttpStatus.OK);
     }
@@ -62,8 +62,8 @@ public class MemberController {
      * 회원탈퇴(withdraw) 후 성공 메세지 반환
      * @return "data" : "성공 메세지"
      */
-    @DeleteMapping("/remove/{member_id}")
-    public ResponseEntity<SingleResDto<String>> withdrawMember (@PathVariable("member_id") Long memberId) {
+    @DeleteMapping("/remove/{member-id}")
+    public ResponseEntity<SingleResDto<String>> withdrawMember (@PathVariable("member-id") Long memberId) {
         memberService.withdrawMember(memberId);
 
         return new ResponseEntity<>(new SingleResDto<>("Success Withdraw"), HttpStatus.OK);
@@ -74,8 +74,8 @@ public class MemberController {
      * 회원 삭제 메소드
      * @return 삭제 성공 메세지
      */
-    @DeleteMapping("/delete/{member_id}")
-    public ResponseEntity<SingleResDto<String>> deleteMember (@PathVariable("member_id") Long memberId) {
+    @DeleteMapping("/delete/{member-id}")
+    public ResponseEntity<SingleResDto<String>> deleteMember (@PathVariable("member-id") Long memberId) {
         memberService.removeMember(memberId);
 
         return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
@@ -86,8 +86,8 @@ public class MemberController {
      * 단일 Get 요청
      * @return "data" : "단일 객체에 대한 응답정보"
      */
-    @GetMapping("/find/{member_id}")
-    public ResponseEntity<SingleResDto<MemberResDto>> getMember (@PathVariable("member_id") Long memberId) {
+    @GetMapping("/find/{member-id}")
+    public ResponseEntity<SingleResDto<MemberResDto>> getMember (@PathVariable("member-id") Long memberId) {
         Member member = memberService.findMember(memberId);
         MemberResDto response = new MemberResDto(member);
 
@@ -113,8 +113,8 @@ public class MemberController {
      * password 확인 : 성공시 String 메세지, 실패시 BusinessLoginException 발생
      * 추후 Password 인코더 구현 시 추가 작업 예정
      */
-    @PostMapping("/verify/{member_id}")
-    public ResponseEntity<SingleResDto<String>> checkPassword(@PathVariable("member_id") Long memberId,
+    @PostMapping("/verify/{member-id}")
+    public ResponseEntity<SingleResDto<String>> checkPassword(@PathVariable("member-id") Long memberId,
                                                               @RequestBody PasswordReqDto passwordDto) {
         memberService.verifyPassword(passwordDto.getPassword(), memberId);
 
@@ -131,7 +131,7 @@ public class MemberController {
      * @param email
      * @return
      */
-    @GetMapping("/verify_email")
+    @GetMapping("/verify-email")
     public ResponseEntity<SingleResDto<String>> checkEmail(@RequestParam(required = false) String email) {
         memberService.verifyEmail(email);
 
@@ -143,7 +143,7 @@ public class MemberController {
      * @param nickname
      * @return
      */
-    @GetMapping("/verify_nickname")
+    @GetMapping("/verify-nickname")
     public ResponseEntity<SingleResDto<String>> checkNickname(@RequestParam(required = false) String nickname) {
         memberService.verifyNickname(nickname);
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -5,18 +5,18 @@ import TeamBigDipper.UYouBooDan.global.dto.SingleResDto;
 import TeamBigDipper.UYouBooDan.member.dto.MemberPatchReqDto;
 import TeamBigDipper.UYouBooDan.member.dto.MemberPostReqDto;
 import TeamBigDipper.UYouBooDan.member.dto.MemberResDto;
+import TeamBigDipper.UYouBooDan.member.dto.PasswordReqDto;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @RestController
@@ -100,13 +100,54 @@ public class MemberController {
      * @return "data" : "String"
      */
     @GetMapping("/find-all")
-    public ResponseEntity<MultiResDto<String>> getMembers (Pageable pageable) {
-        List<String> list = new ArrayList<>();
-        int count = 0;
-        while(count++<30) list.add("Member " + count);
-        Page<String> page = new PageImpl<>(list, pageable, list.size());
+    public ResponseEntity<MultiResDto<MemberResDto>> getMembers (Pageable pageable) {
+        Page<Member> page = memberService.findMembers(pageable);
+        Page<MemberResDto> response = page.map(MemberResDto::new);
+        List<MemberResDto> list = response.stream().collect(Collectors.toList());
 
         return new ResponseEntity<>(new MultiResDto<>(list, page), HttpStatus.OK);
+    }
+
+
+    /**
+     * password 확인 : 성공시 String 메세지, 실패시 BusinessLoginException 발생
+     * 추후 Password 인코더 구현 시 추가 작업 예정
+     */
+    @GetMapping("/verify/{member_id}")
+    public ResponseEntity<SingleResDto<String>> checkPassword(@PathVariable("member_id") Long memberId,
+                                                              @RequestBody(required = false) PasswordReqDto passwordDto) {
+        memberService.verifyPassword(passwordDto.getPassword(), memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
+    }
+
+
+/**
+ * email확인 및 nickname 확인 API 다음작업시 구현예정 (현재는 Handler메소드만 구현)
+ */
+
+    /**
+     * email 중복확인
+     * @param email
+     * @return
+     */
+    @GetMapping("/verify_email")
+    public ResponseEntity<SingleResDto<String>> checkEmail(@RequestParam(required = false) String email) {
+        memberService.verifyEmail(email);
+
+        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
+    }
+
+    /**
+     * 닉네임 중복확인
+     * @param nickname
+     * @return
+     */
+    @GetMapping("/verify_nickname")
+    public ResponseEntity<SingleResDto<String>> checkNickname(@RequestParam(required = false) String nickname) {
+        memberService.verifyNickname(nickname);
+
+        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
     }
 
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -4,6 +4,7 @@ import TeamBigDipper.UYouBooDan.global.dto.MultiResDto;
 import TeamBigDipper.UYouBooDan.global.dto.SingleResDto;
 import TeamBigDipper.UYouBooDan.member.dto.MemberPatchReqDto;
 import TeamBigDipper.UYouBooDan.member.dto.MemberPostReqDto;
+import TeamBigDipper.UYouBooDan.member.dto.MemberResDto;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -58,25 +59,39 @@ public class MemberController {
      * Delete 요청
      * 애너테이션은 delete 요청을 받을 것이므로, DeleteMapping으로 받음
      * 상태변환을 할 예정이므로, HttpStatus는 NO_CONTENT가 아닌 OK로 함
-     * @return "data" : "String"
+     * 회원탈퇴(withdraw) 후 성공 메세지 반환
+     * @return "data" : "성공 메세지"
      */
-    @DeleteMapping("/remove")
-    public ResponseEntity<SingleResDto<String>> deleteMember () {
-        /**
-         * 로그인한 사용자 Id값을 받아 상태 변환 예정
-         */
+    @DeleteMapping("/remove/{member_id}")
+    public ResponseEntity<SingleResDto<String>> withdrawMember (@PathVariable("member_id") Long memberId) {
+        memberService.withdrawMember(memberId);
+
+        return new ResponseEntity<>(new SingleResDto<>("Success Withdraw"), HttpStatus.OK);
+    }
+
+
+    /**
+     * 회원 삭제 메소드
+     * @return 삭제 성공 메세지
+     */
+    @DeleteMapping("/delete/{member_id}")
+    public ResponseEntity<SingleResDto<String>> deleteMember (@PathVariable("member_id") Long memberId) {
+        memberService.removeMembers(memberId);
+
         return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
     }
 
 
     /**
      * 단일 Get 요청
-     * @return "data" : "String"
+     * @return "data" : "단일 객체에 대한 응답정보"
      */
-    @GetMapping("/find")
-    public ResponseEntity<SingleResDto<String>> getMember () {
+    @GetMapping("/find/{member_id}")
+    public ResponseEntity<SingleResDto<MemberResDto>> getMember (@PathVariable("member_id") Long memberId) {
+        Member member = memberService.findMember(memberId);
+        MemberResDto response = new MemberResDto(member);
 
-        return new ResponseEntity<>(new SingleResDto<>("Success Get"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>(response), HttpStatus.OK);
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -76,7 +76,7 @@ public class MemberController {
      */
     @DeleteMapping("/delete/{member_id}")
     public ResponseEntity<SingleResDto<String>> deleteMember (@PathVariable("member_id") Long memberId) {
-        memberService.removeMembers(memberId);
+        memberService.removeMember(memberId);
 
         return new ResponseEntity<>(new SingleResDto<>("Success Delete"), HttpStatus.OK);
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -113,9 +113,9 @@ public class MemberController {
      * password 확인 : 성공시 String 메세지, 실패시 BusinessLoginException 발생
      * 추후 Password 인코더 구현 시 추가 작업 예정
      */
-    @GetMapping("/verify/{member_id}")
+    @PostMapping("/verify/{member_id}")
     public ResponseEntity<SingleResDto<String>> checkPassword(@PathVariable("member_id") Long memberId,
-                                                              @RequestBody(required = false) PasswordReqDto passwordDto) {
+                                                              @RequestBody PasswordReqDto passwordDto) {
         memberService.verifyPassword(passwordDto.getPassword(), memberId);
 
         return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPatchReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPatchReqDto.java
@@ -13,16 +13,17 @@ public class MemberPatchReqDto {
     private String password;
     private String nickname;
     private String profile;
+    private Member.MemberStatus memberStatus; // MemberStatus의 에러 해결 후 활성화 예정입니다.
 
-//    private Member.MemberStatus memberStatus; // MemberStatus의 에러 해결 후 활성화 예정입니다.
-
-
+    /**
+     * 밸류지정방식
+     */
     public Member toEntity() {
         Member member = new Member().builder()
                 .password(new Password(this.password))
                 .nickname(new Name(this.nickname))
                 .profile(new Photo(this.profile))
-//                .memberStatus(this.memberStatus) // MemberStatus의 에러 해결 후 활성화 예정입니다.
+                .memberStatus(this.memberStatus) // MemberStatus의 에러 해결 후 활성화 예정입니다.
                 .build();
         return member;
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPostReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPostReqDto.java
@@ -25,6 +25,7 @@ public class MemberPostReqDto {
                 .password(new Password(this.password))
                 .nickname(new Name(this.nickname))
                 .profile(new Photo(this.profile))
+                .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
                 .build();
         return member;
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
@@ -7,6 +7,8 @@ import lombok.Setter;
 @Getter @Setter
 public class MemberResDto {
 
+    private Long memberId;
+
     private String email;
 
     private String nickname;
@@ -17,6 +19,7 @@ public class MemberResDto {
 
 
     public MemberResDto(Member member) {
+        this.memberId = member.getMemberId();
         this.email = member.getEmail().getEmail();
         this.nickname = member.getNickname().getName();
         this.profile = member.getProfile().getPhoto();

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
@@ -1,0 +1,27 @@
+package TeamBigDipper.UYouBooDan.member.dto;
+
+import TeamBigDipper.UYouBooDan.member.entity.Member;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class MemberResDto {
+
+    private String email;
+
+    private String nickname;
+
+    private String profile;
+
+    private String memberStatus;
+
+
+    public MemberResDto(Member member) {
+        this.email = member.getEmail().getEmail();
+        this.nickname = member.getNickname().getName();
+        this.profile = member.getProfile().getPhoto();
+        this.memberStatus = member.getMemberStatus().getStatus();
+    }
+}
+
+

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/PasswordReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/PasswordReqDto.java
@@ -1,0 +1,9 @@
+package TeamBigDipper.UYouBooDan.member.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+public class PasswordReqDto {
+    private String password;
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -81,11 +81,14 @@ public class Member extends BaseTimeEntity {
     public void modifyProfile(Photo profile){
         this.profile = profile;
     }
-
     public void modifyMemberStatus(MemberStatus status){
         this.memberStatus = status;
     }
-
     public void withdrawMember(){ this.memberStatus = MemberStatus.MEMBER_QUIT; }
+    public void checkPassword(String password) {
+        System.out.println(this.password.getPassword());
+        System.out.println(password);
+        if(!this.password.getPassword().equals(password)) throw new BusinessLogicException(ExceptionCode.NON_ACCESS_MODIFY);
+    }
 
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -17,11 +17,10 @@ import java.util.Optional;
 @Builder
 @Getter
 @Entity
-public class Member {  // extends BaseTimeEntity문제가 발생하여 추후 수정후 적용할 예정
+public class Member extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    @Column(name = "memberId")
     private Long memberId;
 
     @Embedded
@@ -36,13 +35,9 @@ public class Member {  // extends BaseTimeEntity문제가 발생하여 추후 �
     @Embedded
     private Photo profile;
 
-    /**
-     * Unable to instantiate custom type: org.hibernate.type.EnumType 에러발생
-     * 에러 수정 후 활성화 할 예정입니다.
-     */
-//    @Enumerated(EnumType.STRING)
-//    @Builder.Default
-//    private Enum memberStatus = MemberStatus.MEMBER_ACTIVE;
+    @Enumerated(value = EnumType.STRING)
+    @Column(length = 20, nullable = false)  // 컬럼설정 지정 안할시 오류 발생 => Unable to instantiate custom type: org.hibernate.type.EnumType 에러발생
+    private MemberStatus memberStatus;
 
 
     /**
@@ -86,5 +81,11 @@ public class Member {  // extends BaseTimeEntity문제가 발생하여 추후 �
     public void modifyProfile(Photo profile){
         this.profile = profile;
     }
+
+    public void modifyMemberStatus(MemberStatus status){
+        this.memberStatus = status;
+    }
+
+    public void withdrawMember(){ this.memberStatus = MemberStatus.MEMBER_QUIT; }
 
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -86,8 +86,6 @@ public class Member extends BaseTimeEntity {
     }
     public void withdrawMember(){ this.memberStatus = MemberStatus.MEMBER_QUIT; }
     public void checkPassword(String password) {
-        System.out.println(this.password.getPassword());
-        System.out.println(password);
         if(!this.password.getPassword().equals(password)) throw new BusinessLogicException(ExceptionCode.NON_ACCESS_MODIFY);
     }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -79,8 +79,7 @@ public class MemberService {
      * @return : 1명의 member 정보를 반환 => 맞춰서 ResponseDto 제작 예정
      */
     public Member findMember(Long memberId) {
-        Member member = memberRepository.findById(memberId)
-                .orElseThrow(()->new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
+        Member member = new Member().verifyMember(memberRepository.findById(memberId));
         return member;
     }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -33,13 +33,20 @@ public class MemberService {
         return memberRepository.save(member);
     }
 
-
+    /**
+     * 들어오는 값에 따라, 다음의 Patch 요청을 개별적으로 관리 가능합니다. (null이 아닐경우 수정되는 방식 미적용)
+     * 1. 회원 정보 변경 가능
+     * 2. 회원 상태 변경 가능
+     * 비즈니스 로직은 Member Entity 내에서 처리
+     * @param memberId 추후 JWT에서 추출 예정
+     */
     @Transactional
     public void modifyMember(Member member, Long memberId) {
-        Member existMember = (memberRepository.findById(memberId)).get();
+        Member existMember = new Member().verifyMember(memberRepository.findById(memberId));
         Optional.ofNullable(member.getPassword()).ifPresent(existMember::modifyPassword);
         Optional.ofNullable(member.getNickname()).ifPresent(existMember::modifyNickname);
         Optional.ofNullable(member.getProfile()).ifPresent(existMember::modifyProfile);  // 현재 profile의 경우 단순 URI상태. 추후 파일로 변경 예정
+        Optional.ofNullable(member.getMemberStatus()).ifPresent(existMember::modifyMemberStatus);
 
         memberRepository.save(existMember);
     }
@@ -51,6 +58,24 @@ public class MemberService {
      * 2. findMembers => DB 구성 완료 후 구현 예정 (현재는 Controller 내 더미데이터 반환)
      */
 
+    /**
+     * Member 완전 삭제시 사용
+     */
+    @Transactional
+    public void removeMembers (Long memberId) {
+        Member verifyMember = new Member().verifyMember(memberRepository.findById(memberId));
+        memberRepository.delete(verifyMember);
+    }
+
+    /**
+     * Member Entity클래스 내 구현한 회원탈퇴 메소드(withdrawMember 호출)
+     */
+    @Transactional
+    public void withdrawMember (Long memberId) {
+        Member verifyMember = new Member().verifyMember(memberRepository.findById(memberId));
+        verifyMember.withdrawMember();
+        memberRepository.save(verifyMember);
+    }
 
     /**
      * 현재는 Controller에서 String 반환중

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -2,7 +2,6 @@ package TeamBigDipper.UYouBooDan.member.service;
 
 import TeamBigDipper.UYouBooDan.global.exception.dto.BusinessLogicException;
 import TeamBigDipper.UYouBooDan.global.exception.exceptionCode.ExceptionCode;
-import TeamBigDipper.UYouBooDan.member.dto.PasswordReqDto;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -59,7 +58,7 @@ public class MemberService {
      * Member 완전 삭제시 사용
      */
     @Transactional
-    public void removeMembers (Long memberId) {
+    public void removeMember(Long memberId) {
         Member verifyMember = new Member().verifyMember(memberRepository.findById(memberId));
         memberRepository.delete(verifyMember);
     }
@@ -97,7 +96,6 @@ public class MemberService {
 
     /**
      * password 일치 여부 조회 메소드
-     * @param passwordDto
      * @param memberId
      */
     public void verifyPassword (String password, Long memberId) {

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -2,9 +2,12 @@ package TeamBigDipper.UYouBooDan.member.service;
 
 import TeamBigDipper.UYouBooDan.global.exception.dto.BusinessLogicException;
 import TeamBigDipper.UYouBooDan.global.exception.exceptionCode.ExceptionCode;
+import TeamBigDipper.UYouBooDan.member.dto.PasswordReqDto;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -53,12 +56,6 @@ public class MemberService {
 
 
     /**
-     * 추후 구현할 기본 메서드
-     * 1. removeMember => 상태 ENUM 문제 해결 후 구현 예정
-     * 2. findMembers => DB 구성 완료 후 구현 예정 (현재는 Controller 내 더미데이터 반환)
-     */
-
-    /**
      * Member 완전 삭제시 사용
      */
     @Transactional
@@ -88,4 +85,36 @@ public class MemberService {
         return member;
     }
 
+
+    /**
+     * 전체 회원 조회용 (Default는 10계정)
+     * @param pageable : page, size, sort 등 사용 가능
+     * @return Page 구조
+     */
+    public Page<Member> findMembers (Pageable pageable) {
+        return memberRepository.findAll(pageable);
+    }
+
+    /**
+     * password 일치 여부 조회 메소드
+     * @param passwordDto
+     * @param memberId
+     */
+    public void verifyPassword (String password, Long memberId) {
+        Member member = new Member().verifyMember(memberRepository.findById(memberId));
+        member.checkPassword(password);
+    }
+
+
+    public void verifyEmail (String email) {
+        /**
+         * 중복확인 쿼리 메서드 구현하기
+          */
+    }
+
+    public void verifyNickname (String nickname) {
+        /**
+         * 중복확인 쿼리 메서드 구현하기
+         */
+    }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Email.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Email.java
@@ -1,6 +1,7 @@
 package TeamBigDipper.UYouBooDan.member.value;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
@@ -8,4 +9,5 @@ import javax.persistence.Embeddable;
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Email { private String email; }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Name.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Name.java
@@ -1,6 +1,7 @@
 package TeamBigDipper.UYouBooDan.member.value;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;
@@ -8,4 +9,5 @@ import javax.persistence.Embeddable;
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Name { private String name; }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Password.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Password.java
@@ -9,4 +9,5 @@ import javax.persistence.Embeddable;
 @Embeddable
 @AllArgsConstructor
 @NoArgsConstructor
+@Getter
 public class Password { private String password; }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Password.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/value/Password.java
@@ -1,6 +1,7 @@
 package TeamBigDipper.UYouBooDan.member.value;
 
 import lombok.AllArgsConstructor;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.Embeddable;

--- a/BE/UYouBooDan/src/main/resources/application.yml
+++ b/BE/UYouBooDan/src/main/resources/application.yml
@@ -7,6 +7,8 @@ server:
       force: true
 
 spring:
+  profiles:
+    active: local   # 로컬 프로파일 사용을 위한 설정
   jpa:
     hibernate:
       ddl-auto: create


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [ ] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: feat#31


## 무엇이 추가 되었나요?

- Member 탈퇴 API : MEMBER_QUIT으로 상태변경
- Member 삭제 API : DB에서 계정 삭제
- Member 단일회원조회 API : 단일 계정에 대한 정보 조회
- Member 전체회원 페이지조회 API : 페이지네이션 적용 완료
- Member 비밀번호 확인 API 구현 API : password인코더 구현 후 추가작업 예정
- Member Email 중복확인 : 핸들러메서드만 작성 => 다음 작업 시 기능 구현예정
- Member Nickname 중복확인 : 핸들러메서드만 작성 => 다음 작업 시 기능 구현예정

## 기타 정보

- 현재 시큐리티 미구현으로 PathVariable에 member_id가 필요합니다.
- 추후 시큐리티 적용 후 JWT를 이용한 자체 검증으로 변경 예정입니다.
- 이전 PR에서 있었던 상태관리 및 BaseTime 이슈를 해결했습니다.
- BaseTime사용을 위해 엔트리 포인트에 이벤트 리스너 애너테이션을 추가했습니다.