### PR TITLE
[BE] 진행 중인/마감 임박/종료된 투표 게시글 목록 조회 기능 구현 #63

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
@@ -17,7 +17,8 @@ public enum ExceptionCode {
     NICKNAME_EXIST(401, "중복된 닉네임 입니다."),
     NAT_EXACT_PASSWORD(401,"비밀번호가 일치하지 않습니다."),
     LOGIN_REQUIRED(401, "로그인이 필요한 서비스 입니다."),
-    TOPIC_NOT_EXIST(404, "존재하지 않는 게시글 입니다.")
+    TOPIC_NOT_EXIST(404, "존재하지 않는 게시글 입니다."),
+    FILTER_NOT_EXIST(400, "잘못된 조회 필터 입니다")
     ;
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -73,14 +73,17 @@ public class TopicController {
     }
 
     /**
-     * 투표 게시글 전체 조회
+     * 투표 게시글 목록 전체 조회
+     * - filter 값을 통해서 진행중, 마감된, 마감 임박 투표 게시글 조회 가능
      * @param pageable Pageable 객체
-     * @return 투표게시글 전체 리스트, Page 관련 정보, HttpStatus
+     * @param filter 투표 게시글 필터 : String 객체
+     * @return 페이지네이션이 적용된 투표 게시글 목록 리스트, Page 관련 정보 HttpStatus
      */
     @GetMapping
-    public ResponseEntity<MultiResDto> getTopics(Pageable pageable) {
-        // TopicService에서 투표 게시글 Topic Page 반환
-        Page<Topic> topicPage = topicService.findTopics(pageable);
+    public ResponseEntity<MultiResDto> getTopics(Pageable pageable,
+                                                 @RequestParam(value = "filter", required = false) String filter) {
+        // TopicService에서 Pageable객체와 filter를 통해 투표 게시글 Topic Page 반환
+        Page<Topic> topicPage = topicService.findTopics(pageable, filter);
 
         // Page Topic을 Response DTO로 변환
         Page<TopicPageResDto> topicPageResDtos = topicPage.map(TopicPageResDto::new);
@@ -92,5 +95,4 @@ public class TopicController {
         // Topic Page Response DTO, Page 정보, HTTP Status 반환
         return new ResponseEntity<>(new MultiResDto<>(topicPageResDtoList, topicPage), HttpStatus.OK);
     }
-
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
@@ -5,7 +5,36 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+
 public interface TopicRepository extends JpaRepository<Topic, Long> {
     // 투표 게시글 전체 목록을 Pagination 이용해서 작성 날짜 역순으로 조회
     Page<Topic> findAllByOrderByCreatedAtDesc(Pageable pageable);
+
+    /**
+     * 진행 중인 투표 게시글 목록을 Pagination 적용해서 작성일 내림차순으로 조회
+     * @param now 현재 날짜 : LocalDateTime 객체
+     * @param pageable pagination 객체
+     * @return Pagination 적용된 Topic 객체
+     */
+    Page<Topic> findAllByClosedAtIsAfterOrderByCreatedAtDesc(LocalDateTime now, Pageable pageable);
+
+    /**
+     * 마감 임박 투표 게시글 목록을 Pagination 적용해서 현재날짜와 마감 임박까지 마감일 오름차순으로 조회
+     * @param start 현재 날짜 : LocalDateTime 객체
+     * @param end 현재 날짜로부터 마감임박 제한 날짜 : LocalDateTime 객체
+     * @param pageable Pagination 객체
+     * @return Pagination 적용된 Topic 객체
+     */
+    Page<Topic> findAllByClosedAtBetweenOrderByClosedAtAsc(LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    // TODO: 전체 게시글 중 핫토픽 조회
+
+    /**
+     * 투표 마감된 투표 게시글 목록을 Pagination 적용해서 작성일 내림차순으로 조회
+     * @param now 현재 날짜 : LocalDateTime 객체
+     * @param pageable Pagination 객체
+     * @return Pagination 적용된 Topic 객체
+     */
+    Page<Topic> findAllByClosedAtIsBeforeOrderByCreatedAtDesc(LocalDateTime now, Pageable pageable);
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
@@ -8,7 +8,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.time.LocalDateTime;
 
 public interface TopicRepository extends JpaRepository<Topic, Long> {
-    // 투표 게시글 전체 목록을 Pagination 이용해서 작성 날짜 역순으로 조회
+    /**
+     * 투표 게시글 전체 목록을 Pagination 이용해서 작성 날짜 역순으로 조회
+     * @param pageable Pageable 객체
+     * @return Pagination 적용된 Page Topic 객체
+     */
     Page<Topic> findAllByOrderByCreatedAtDesc(Pageable pageable);
 
     /**

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
@@ -6,12 +6,13 @@ import TeamBigDipper.UYouBooDan.topic.entity.Topic;
 import TeamBigDipper.UYouBooDan.topic.entity.TopicVoteItem;
 import TeamBigDipper.UYouBooDan.topic.repository.TopicRepository;
 import TeamBigDipper.UYouBooDan.topic.repository.TopicVoteItemRepository;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -59,11 +60,85 @@ public class TopicService {
     }
 
     /**
-     * Pagination을 적용하여 투표 게시글 전체 목록 조회
+     * Pagination을 적용하여 투표 게시글 전체 목록조회
+     * filter 값을 통해서 진행중, 마감된, 마감 임박 투표 게시글 조회 가능
      * @param pageable Pageable 객체
-     * @return Page<Topic> Topic클래스 타입의 Page
+     * @param topicFilter 투표 게시글 필터 : String 객체
+     * @return Page<Topic> Topic 클래스 타입의 Page
      */
-    public Page<Topic> findTopics(Pageable pageable) {
+    public Page<Topic> findTopics(Pageable pageable, String topicFilter) {
+
+        // 현재 시간
+        LocalDateTime now = LocalDateTime.now();
+        // 투표 게시글 마감 임박까지 남은 시간
+        int imminentHour = 6;
+        // 투표 게시글 마감 시간 - 현재 시간으로부터 투표 게시글 마감 임박까지 시간을 더함
+        LocalDateTime end = LocalDateTime.now().plusHours(imminentHour);
+
+        // 문자열로 된 topicFilter를 enum으로 변경 후 해당 Filter enum에 맞게 리턴
+        switch(TopicFilter.nameOf(topicFilter)) {
+            // 투표 게시글 전체 목록 조회
+            case ALL:
+                break;
+            // 진행 중인 투표 게시글 목록 조회 - 작성일 기준 내림차순, 페이지네이션 적용
+            case PROGRESS:
+                return topicRepository.findAllByClosedAtIsAfterOrderByCreatedAtDesc(now, pageable);
+            // 마감 임박 투표 게시글 목록 조회
+            case IMMINENT:
+                return topicRepository.findAllByClosedAtBetweenOrderByClosedAtAsc(now, end, pageable);
+            // 전체 게시글 중 핫토픽 조회
+            case HOT:
+                break;
+            // 투표 마감된 투표 게시글 목록 조회
+            case CLOSED:
+                return topicRepository.findAllByClosedAtIsBeforeOrderByCreatedAtDesc(now, pageable);
+        }
+
+        // 페이지네이션 처리된 투표 게시글 전체 목록을 작성일 내림차순으로 정렬한 Tage<Topic> 반환
         return topicRepository.findAllByOrderByCreatedAtDesc(pageable);
+    }
+
+    /**
+     * TopicFilter Enum 클래스
+     */
+    public enum TopicFilter {
+
+        ALL("all"),             // 전체
+        PROGRESS("progress"),   // 진행 중인
+        IMMINENT("imminent"),   // 마감 임박인
+        HOT("hot"),             // 핫 토픽
+        CLOSED("closed")         // 종료된
+        ;
+
+        @Getter
+        private String topicFilterName;         // 투표 게시글 필터 이름
+
+        /**
+         * TopicFilter 생성자
+         * @param topicFilterName  투표 게시글 필터 이름 : String 객체
+         */
+        TopicFilter(String topicFilterName) {this.topicFilterName = topicFilterName;}
+
+        /**
+         * 투표 게시글 필터 이름에 맞는 Enum 객체 찾아서 출력
+         * @param topicFilterName   투표 게시글 필터 이름 : String 객체
+         * @return 투표 게시글 필터 Enum 객체
+         */
+        public static TopicFilter nameOf(String topicFilterName) {
+            // 필터가 없으면 전체 목록 조회
+            if (topicFilterName == null) {
+                return TopicFilter.ALL;
+            }
+
+            // TopicFilter Enum 객체 순회하면서
+            for (TopicFilter topicFilter : TopicFilter.values()) {
+                // 투표 게시글 필터 이름에 맞는 Enum 객체 반환
+                if(topicFilter.getTopicFilterName().equals(topicFilterName)){
+                    return topicFilter;
+                }
+            }
+            // 이름이 일치하지 않으면 존재하지 않는 필터 예외 처리
+            throw new BusinessLogicException(ExceptionCode.FILTER_NOT_EXIST);
+        }
     }
 }


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #63 


## 무엇이 추가 되었나요?

- TopicController 클래스 내 getTopics 핸들러메서드에 filter Query Parameter 추가
- TopicController 클래스 내 TopicService 클래스의 findTopics 메서드 호출시 filter 추가
- TopicController 클래스 주석 변경
- TopicService 클래스의 findTopics 메서드 매개 변수에 filter 추가
- TopicService 클래스 내 투표 게시글 목록 조회에 대한 필터 TopicFilter Enum 클래스 추가
- TopicService 클래스의 findTopics 메서드 내 TopicFilter Enum 값에 따라 각각의 repository 메서드 호출
- TopicRepository 인터페이스에 투표 게시글 각 필터에 따라 조회하도록 쿼리메서드 추가
- ExceptionCode Enum클래스에 투표 게시글 조회시 쿼리 파라미터로 필터를 잘못 설정했을 때에 대한 ExceptionCode 추가
- TopicRepository 인터페이스 내 투표 게시글 전체 목록 조회하는 쿼리메서드 주석 변경
-
## 기타 정보
- 진행중인, 마감임박, 종료중인에 대한 필터를 enum 객체를 통해서 관리해서 서비스에서 확인하여 switch문을 통해 각 해당하는 필터에 맞게 Repository의 쿼리 메서드를 부르도록 구현하였습니다. 
- 핫 토픽 게시글 목록 조회 기능 구현은 게시글 좋아요 기능 구현 완료 후 진행하겠습니다. 