### PR TITLE
[BE] Email, Nickname, Password 검증 API, CORS webConfig, 카카오 로그인 프론트 연결, 더미데이터SQL Feat#53

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
@@ -15,7 +15,7 @@ public enum ExceptionCode {
 
     EMAIL_EXIST(401, "중복된 이메일 입니다."),
     NICKNAME_EXIST(401, "중복된 닉네임 입니다."),
-    NAT_EXACT_PASSWORD(401,"비밀번호가 일치하지 않습니다."),
+    NOT_EXACT_PASSWORD(401,"비밀번호가 일치하지 않습니다."),
     LOGIN_REQUIRED(401, "로그인이 필요한 서비스 입니다.");
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -43,7 +43,7 @@ public class KakaoOauthController {
         StringBuffer url = new StringBuffer();
         url.append("https://kauth.kakao.com/oauth/authorize?");
         url.append("client_id=" + getKakaoAppKey()); // App Key
-        url.append("&redirect_uri=http://www.localhost:3000/main"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
+        url.append("&redirect_uri=http://www.localhost:3000/auth/kakaoredirect"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
         url.append("&response_type=code");
 
         return new ResponseEntity<>(url.toString(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -1,7 +1,6 @@
 package TeamBigDipper.UYouBooDan.global.oauth2.kakao;
 
 import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
-import TeamBigDipper.UYouBooDan.global.security.util.CustomAuthorityUtils;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.service.MemberService;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -28,6 +27,9 @@ public class KakaoOauthController {
     @Getter
     @Value("${oauth.kakao.appKey.restApiKey}")
     private String kakaoAppKey;
+    @Getter
+    @Value("${oauth.kakao.clientId}")
+    private String kakaoClientId;
     private final MemberService memberService;
     private final JwtTokenizer jwtTokenizer;
 
@@ -37,21 +39,20 @@ public class KakaoOauthController {
      * @return redirect url for kakao Authorization
      */
     @GetMapping("/oauth")
-    public String kakaoConnect() {
+    public ResponseEntity<?> kakaoConnect() {
         StringBuffer url = new StringBuffer();
         url.append("https://kauth.kakao.com/oauth/authorize?");
         url.append("client_id=" + getKakaoAppKey()); // App Key
-        url.append("&redirect_uri=http://www.localhost:8080/kakao/callback"); // 경로 확인 (아래 핸들러 메소드?)
+        url.append("&redirect_uri=http://www.localhost:3000/main"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
         url.append("&response_type=code");
 
-//        return new ResponseEntity<>(url.toString(), HttpStatus.MOVED_PERMANENTLY); // 자동 Redirect 메소드
-        return "redirect: " + url;
+        return new ResponseEntity<>(url.toString(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)
     }
 
 
     /**
      * 카카오 callback API : 토큰 발급 및 서비스 멤버 생성
-     * @param code 카카오 인증 code
+     * @param code 카카오 인증 code (프론트에서 카카오로부터 받아서 이 API에 담아서 전달해주면 됨)
      * @return Success Login message
      * @throws JsonProcessingException
      */

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/SecurityConfiguration.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/SecurityConfiguration.java
@@ -32,7 +32,8 @@ public class SecurityConfiguration {
         return httpSecurity
                 .headers().frameOptions().sameOrigin() // 동일 출처로부터 들어오는 request만 페이지 렌더링 허용
                 .and()
-                .cors(withDefaults())
+                .cors()
+                .and()
                 .csrf().disable()
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)
                 .and()

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/webConfig.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/webConfig.java
@@ -7,18 +7,23 @@ import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 @Configuration
 public class webConfig implements WebMvcConfigurer {
 
+    /**
+     * "http://localhost:3000" : 브라우저용 (www붙이면 CORS 발생)
+     * "http://www.localhost:3000" : 카카오 리다이렉션용 (WWW 안붙이면 카카오에서 등록이 안됨)
+     *
+     */
     @Override
     public void addCorsMappings (CorsRegistry registry) {
 
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:8080", "http://localhost:8090", "http://localhost:5173",
-                        "http://localhost:63342")
+                        "http://localhost:63342", "http://www.localhost:3000", "http://localhost:3000")
                 .allowedHeaders("*")
                 .allowedMethods("GET", "POST", "PATCH", "DELETE")
                 .maxAge(3600)
                 .allowCredentials(true)
                 .allowedHeaders("*")
-//                .allowedOriginPatterns()
+                .allowedOriginPatterns()
                 .exposedHeaders("*");
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtAuthenticationFilter.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtAuthenticationFilter.java
@@ -64,8 +64,8 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         Member authenticatedMember = (Member) authResult.getPrincipal();
         String accessToken = jwtTokenizer.delegateAccessToken(authenticatedMember);
         String refreshToken = jwtTokenizer.delegateRefreshToken(authenticatedMember);
-        response.setHeader("Authentication", "Bearer " + accessToken);
-        response.setHeader("RefreshToken", refreshToken);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("RefreshToken", refreshToken); // 쿠키에 넣기
         this.getSuccessHandler().onAuthenticationSuccess(request, response, authResult);
     }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -128,10 +128,6 @@ public class MemberController {
 
 
     /**
-     * email확인 및 nickname 확인 API 다음작업시 구현예정 (현재는 Handler메소드만 구현)
-     */
-
-    /**
      * email 중복확인
      * @param email
      * @return 사용 가능시 : data "사용 가능한 이메일입니다.", 사용 불가시 : EMAIL_EXIST(401, "중복된 이메일 입니다.")

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController {
         Long memberId = jwtExtractUtil.extractMemberIdFromJwt(request);
         memberService.modifyMember(memberPatchReqDto.toEntity(), memberId);
 
-        return new ResponseEntity<>(new SingleResDto<>("Success Patch"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Edit"), HttpStatus.OK);
     }
 
 
@@ -71,7 +71,7 @@ public class MemberController {
     public ResponseEntity<SingleResDto<String>> withdrawMember (HttpServletRequest request) {
         memberService.withdrawMember(jwtExtractUtil.extractMemberIdFromJwt(request));
 
-        return new ResponseEntity<>(new SingleResDto<>("Success Withdraw"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("정상적으로 탈퇴되었습니다."), HttpStatus.OK);
     }
 
 
@@ -123,7 +123,7 @@ public class MemberController {
                                                               HttpServletRequest request) {
         memberService.verifyPassword(passwordDto.getPassword(), jwtExtractUtil.extractMemberIdFromJwt(request));
 
-        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Verify"),HttpStatus.OK);
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -56,7 +56,7 @@ public class MemberController {
         Long memberId = jwtExtractUtil.extractMemberIdFromJwt(request);
         memberService.modifyMember(memberPatchReqDto.toEntity(), memberId);
 
-        return new ResponseEntity<>(new SingleResDto<>("Success Edit"), HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("Success Modify"), HttpStatus.OK);
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -134,26 +134,26 @@ public class MemberController {
     /**
      * email 중복확인
      * @param email
-     * @return
+     * @return 사용 가능시 : data "사용 가능한 이메일입니다.", 사용 불가시 : EMAIL_EXIST(401, "중복된 이메일 입니다.")
      */
     @GetMapping("/verify-email")
     public ResponseEntity<SingleResDto<String>> checkEmail(@RequestParam(required = false) String email) {
         memberService.verifyNotExistEmail(email);
 
-        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("사용 가능한 이메일입니다."),HttpStatus.OK);
     }
 
 
     /**
      * 닉네임 중복확인
      * @param nickname
-     * @return
+     * @return 사용 가능시 : data "사용 가능한 닉네임입니다.", 사용 불가시 : NICKNAME_EXIST(401, "중복된 닉네임 입니다.")
      */
     @GetMapping("/verify-nickname")
     public ResponseEntity<SingleResDto<String>> checkNickname(@RequestParam(required = false) String nickname) {
         memberService.verifyNotExistNickname(nickname);
 
-        return new ResponseEntity<>(new SingleResDto<>("Verify Success."),HttpStatus.OK);
+        return new ResponseEntity<>(new SingleResDto<>("사용 가능한 닉네임입니다."),HttpStatus.OK);
     }
 
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberResDto.java
@@ -1,11 +1,12 @@
 package TeamBigDipper.UYouBooDan.member.dto;
 
+import TeamBigDipper.UYouBooDan.global.auditing.BaseTimeEntity;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import lombok.Getter;
 import lombok.Setter;
 
 @Getter @Setter
-public class MemberResDto {
+public class MemberResDto extends BaseTimeEntity {
 
     private Long memberId;
 
@@ -24,6 +25,8 @@ public class MemberResDto {
         this.nickname = member.getNickname().getName();
         this.profile = member.getProfile().getPhoto();
         this.memberStatus = member.getMemberStatus().getStatus();
+        super.setCreatedAt(member.getCreatedAt());
+        super.setModifiedAt(member.getModifiedAt());
     }
 }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -94,8 +94,4 @@ public class Member extends BaseTimeEntity {
         this.memberStatus = status;
     }
     public void withdrawMember(){ this.memberStatus = MemberStatus.MEMBER_QUIT; }
-    public void checkPassword(String password) {
-        if(!this.password.equals(password)) throw new BusinessLogicException(ExceptionCode.NAT_EXACT_PASSWORD);
-    }
-
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/repository/MemberRepository.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/repository/MemberRepository.java
@@ -10,6 +10,6 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 
     Optional<Member> findByEmail(String email);
 
-//    @Query(value = "SELECT m FROM Member m WHERE m.nickname.name =: nickname")
+    @Query(value = "SELECT m FROM Member m WHERE m.nickname.name =:nickname")
     Optional<Member> findByNickname(String nickname);
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -68,8 +68,10 @@ public class MemberService {
     @Transactional
     public void modifyMember(Member member, Long memberId) {
         Member existMember = new Member().verifyMember(memberRepository.findById(memberId));
+//        Optional.ofNullable(member.getPassword()).ifPresent(pw -> existMember.modifyPassword(passwordEncoder.encode(pw))); // 해제시, 수정중 비밀번호를 필수항목으로 지정 가능
 
-        Optional.ofNullable(member.getPassword()).ifPresent(pw -> existMember.modifyPassword(passwordEncoder.encode(pw))); // 비밀번호는 필수항목? 혹은 비밀번호 변경은 따로 분리?
+        String encodedPassword = passwordEncoder.encode(member.getPassword());
+        Optional.ofNullable(encodedPassword).ifPresent(existMember::modifyPassword);
         Optional.ofNullable(member.getNickname()).ifPresent(existMember::modifyNickname);
         Optional.ofNullable(member.getProfile()).ifPresent(existMember::modifyProfile);  // 현재 profile의 경우 단순 URI상태. 추후 파일로 변경 예정
         Optional.ofNullable(member.getMemberStatus()).ifPresent(existMember::modifyMemberStatus);

--- a/BE/UYouBooDan/src/main/resources/static/db/data.sql
+++ b/BE/UYouBooDan/src/main/resources/static/db/data.sql
@@ -1,0 +1,10 @@
+
+INSERT INTO Member(memberId, createdAt, last_modified_at, email, memberStatus, name, password, photo) VALUES
+(1, '2023-01-01 00:05:33.825730', '2023-01-01 00:05:33.825730', 'asdf1234@gmail.com', 'MEMBER_ACTIVE', '헤이즐넛', '{bcrypt}$2a$10$ps7EXP6V8pxDB0fgsBvbduRzcnHO5sD32FtFQ7tzBfcztBWSRTFIO', 'https://scontent-gmp1-1.xx.fbcdn.net/v/t1.18169-9/527016_499021583525593_732357164_n.jpg?_nc_cat=107&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=CdbnqyyFWXkAX_obHCp&_nc_ht=scontent-gmp1-1.xx&oh=00_AfDBQSsLnCXMKoAPnGFrOeSBgvMp__vgjXLEqmtS6etfcw&oe=63F1DB6A'),
+(2, '2023-02-01 00:05:33.825730', '2023-02-01 00:05:33.825730', 'nyong9221@naver.com', 'MEMBER_ACTIVE', '김동진', '{bcrypt}$2a$10$ps7EXP6V8pxDB0fgsBvbduRzcnHO5sD32FtFQ7tzBfcztBWSRTFIO', 'https://scontent-gmp1-1.xx.fbcdn.net/v/t1.18169-9/527016_499021583525593_732357164_n.jpg?_nc_cat=107&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=CdbnqyyFWXkAX_obHCp&_nc_ht=scontent-gmp1-1.xx&oh=00_AfDBQSsLnCXMKoAPnGFrOeSBgvMp__vgjXLEqmtS6etfcw&oe=63F1DB6A'),
+(3, '2023-02-03 00:05:33.825730', '2023-02-03 00:05:33.825730', 'rlgywnd@naver.com', 'MEMBER_ACTIVE', '김효중', '{bcrypt}$2a$10$ps7EXP6V8pxDB0fgsBvbduRzcnHO5sD32FtFQ7tzBfcztBWSRTFIO', 'https://scontent-gmp1-1.xx.fbcdn.net/v/t1.18169-9/527016_499021583525593_732357164_n.jpg?_nc_cat=107&ccb=1-7&_nc_sid=09cbfe&_nc_ohc=CdbnqyyFWXkAX_obHCp&_nc_ht=scontent-gmp1-1.xx&oh=00_AfDBQSsLnCXMKoAPnGFrOeSBgvMp__vgjXLEqmtS6etfcw&oe=63F1DB6A');
+
+INSERT INTO member_roles(Member_memberId,roles) values
+(1,'USER'),
+(2,'USER'),
+(3,'USER');


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #53 


## 무엇이 추가 되었나요?

- Email 검증 API 수정 (완료)
- Nickname 검증 API 수정 (완료)
- Password 검증 API 수정 (완료)
- 회원정보 수정시, 비밀번호도 수정이 가능하게 수정 (완료)
- CORS controller을 위한 webConfig 클래스 구현
- Kakao Oauth 프론트와 플로우 연결 (완료)
- data.sql : Member 객체 더미데이터용 SQL문 작성

## 기타 정보

- 더미데이터 사용시, 아래의 코드를 local.yml에서 활성화 해주세요. 
  sql:
    init:
      data-locations: classpath:static/db/data.sql
      mode: always
![image](https://user-images.githubusercontent.com/94734089/216392011-57014fc9-0c74-4058-82e7-37c570f8b6cf.png)

- webConfig의 경우, 현재 백엔드에서 주로 사용하는 8080, 8090포트, 프론트용 3000포트가 열려있습니다.
- Security에서 액세스 토큰 발급을 위한 헤더의 키값 오타를 수정했습니다.