### PR TITLE
[BE] 투표 게시글 상세 조회시 응답 추가 및 수정 #98

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -55,13 +55,23 @@ public class TopicController {
 
     /**
      * 투표 게시글 상세 조회
-     * @param topicId 투표 게시글의 id
-     * @return 조회된 투표게시글 상세, HTTP Status
+     * @param topicId 투표 게시글의 id long
+     * @param request HttpServletRequest 객체 - 토큰 확인
+     * @return 조회된 투표 게시글 상세 내용, HTTP Status
      */
     @GetMapping("/{topic-id}")
-    public ResponseEntity getTopic(@PathVariable("topic-id") long topicId) {
+    public ResponseEntity getTopic(@PathVariable("topic-id") long topicId,
+                                   HttpServletRequest request) {
+
+        Long memberId;      // 사용자 id
+        if (false){         // 로그인한 사용자 이면
+            memberId = jwtExtractUtil.extractMemberIdFromJwt(request);      // 요청의 token으로부터 사용자 memberId 추출
+        } else {            // 로그인하지않은 사용자이면
+            memberId = null;
+        }
+
         // topic Service에서 topic id로 투표 게시글 topic 조회
-        Topic topic = topicService.findTopic(topicId);
+        Topic topic = topicService.findTopic(topicId, memberId);
 
         // 투포 게시글 topic을 Response DTO 객체로 변환
         TopicResDto topicResDto = new TopicResDto(topic);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicResDto.java
@@ -53,15 +53,15 @@ public class TopicResDto {
                     TopicVoteItemResDto topicVoteItemResDto = TopicVoteItemResDto.builder()
                             .topicVoteItemId(topicVoteItem.getTopicVoteItemId())
                             .topicVoteItemName(topicVoteItem.getTopicVoteItemName())
+                            .numberOfVotes(topicVoteItem.getTopicVotes().size())
+                            .isTopicVoteItemVoted(topicVoteItem.getTopicVoteItemVoted())
                             .build();
                     return topicVoteItemResDto;})
                 .forEach(topicVoteItemResDto -> topicVoteItems.add(topicVoteItemResDto));
 
         this.author = topic.getMember().getNickname().getName();    // 작성자 nickname
-
-        // TODO: 투표 게시글을 조회하는 사람이 작성자인지 투표했는지 여부
-//        this.isAuthor = topic.getIsAuthor();        // 조회하는 사람이 작성자인지 여부
-//        this.isVoted = topic.getIsVoted();          // 조회하는 사람이 투표했는지 여부
+        this.isAuthor = topic.getIsAuthor();        // 조회하는 사람이 작성자인지 여부
+        this.isVoted = topic.getIsVoted();          // 조회하는 사람이 투표했는지 여부
 
         // TODO: 투표 게시글의 조회수, 좋아요 수
         // views

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -29,8 +29,6 @@ public class Topic extends BaseTimeEntity {
 
     private String content;                 // 투표 게시글 내용
 
-    // private Long topicVoteId;            // 투표 Id
-
     @Enumerated(EnumType.STRING)         // Enum을 String으로 저장
     private TopicStatus topicStatus;     // 투표 게시글 상태
 
@@ -79,6 +77,34 @@ public class Topic extends BaseTimeEntity {
      */
     public void changeTopicStatusRemoved() {
         topicStatus = TopicStatus.REMOVED;
+    }
+
+    /**
+     * 투표 게시글 조회자가 투표 게시글 작성인지 여부 확인
+     * @param memberId 조회하는 사용자의 id Long
+     * @return 투표 게시글 작성자이면 true, 아니면 false
+     */
+    public Boolean findIsAuthor(Long memberId) {
+        // 투표 게시글 작성자 id와 조회하는 사용자의 id가 같은지 여부 확인
+        isAuthor = member.getMemberId().equals(memberId);
+        return isAuthor;
+    }
+
+    /**
+     * 투표 게시글 조회자가 투표 게시글에 투표했는지 여부 확인
+     * @param memberId 조회하는 사용자의 id Long
+     */
+    public void findTopicIsVoted(Long memberId) {
+        isVoted = false;        // 아직 투표 게시글에 투표를 하지 않은 초기 상태
+
+        // 투표 항목 TopicVoteItem 리스트를 순회하면서
+        for (TopicVoteItem topicVoteItem : topicVoteItems) {
+            topicVoteItem.isTopicVoteItemVoted(memberId);   // 투표 항목에 투표했는지 확인
+
+            if (topicVoteItem.getTopicVoteItemVoted()) {    // 투표 항목에 조회자가 투표했으면
+                isVoted = true;                             // 현재 투표 게시글에 투표한 상태
+            }
+        }
     }
 
     /**

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
@@ -42,9 +42,15 @@ public class TopicService {
      * @param topicId 투표 게시글 topic id
      * @return 투표게시글 Topic 객체
      */
-    public Topic findTopic(long topicId) {
-        // 유효한 투표 게시글 Topic 조회해서 반환
-        return findVerifiedTopic(topicId);
+    public Topic findTopic(long topicId, Long memberId) {
+
+        Topic verifiedTopic = findVerifiedTopic(topicId);   // 유효한 투표 게시글 Topic 조회
+
+        verifiedTopic.findTopicIsVoted(memberId);        // 투표 게시글의 투표 항목에 대해 사용자가 투표했는지 확인
+
+        verifiedTopic.findIsAuthor(memberId);           // 조회하는 사람이 투표 게시글 작성자인지 확인
+
+        return verifiedTopic;       // 투표 게시글 Topic 객체 반환
     }
 
     /**


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #98 


## 무엇이 추가 되었나요?

- TopicController 클래스 getTopic 핸들러 메서드에 로그인 여부 확인하여 id 추출하는 로직 추가
- TopicService 클래스 findTopic 메서드에서 투표항목에 사용자가 투표했는지, 조회하는 사람이 투표 게시글 작성자인지 확인하는 로직 추가
- TopicResDto 클래스에 투표항목에 투표수, 조회하는사람이 투표했는지 여부, 작성자인지 여부 응답 추가
-  Topic Entity 클래스에 조회자가 게시글 작성자인지, 투표했는지 여부를 확인하는 메서드 추가

## 기타 정보
- 투표상세 조회했을때에 대해 투표 수, 투표 여부, 작성자 여부 관련 응답을 추가하였습니다. 
- 로그인한 사용자, 로그인 안한 사용자에 따라 작성자인지, 투표했는지 여부 응답이 바뀌는 부분은 동진님께서 Request로부터 Header 여부 확인 메서드 구현 후에 추가적으로 작업하겠습니다. 