### PR TITLE
[BE] 투표 게시글에 대해 1위 투표 항목 보여주는 기능 구현 #111

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPageResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPageResDto.java
@@ -3,7 +3,10 @@ package TeamBigDipper.UYouBooDan.topic.dto;
 import TeamBigDipper.UYouBooDan.topic.entity.Topic;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 투표 게시글 전체 목록 조회시 Response DTO 클래스
@@ -17,6 +20,9 @@ public class TopicPageResDto {
     private String createdAt;   // 작성 날짜
     private String closedAt;    // 마감날짜
 
+    private Boolean isClosed;   // 투표가 마감됐는지 여부
+
+    private List<String> theFirstItemNames; // 1위 투표 항목 - 공동 1위 포함
     /**
      * TopicPageResDto 클래스 생성자
      * @param topic 투표 게시글 Topic 클래스
@@ -30,5 +36,11 @@ public class TopicPageResDto {
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));     // 작성일
         this.closedAt = topic.getClosedAt()
                 .format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss"));     // 마감일
+        isClosed = topic.isTopicClosed(LocalDateTime.now());       // 현재 시간으로부터 투표가 마감됐는지 여부 확인
+
+        theFirstItemNames = new ArrayList<>();                          // DTO의 1위 투표 항목 이름 리스트 생성
+        topic.findTheFirstVoteItemName();                               // 투표 게시글에서 1위 투표 항목 리스트 찾기
+        theFirstItemNames.addAll(topic.getTheFirstItemNames());     // DTO의 1위 투표 항목 이름 리스트에 삽입
+
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicResDto.java
@@ -5,6 +5,7 @@ import TeamBigDipper.UYouBooDan.topic.entity.TopicVoteItem;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.List;
@@ -33,12 +34,16 @@ public class TopicResDto {
     private Long likes;         // 좋아요 수
     private Boolean isLiked;    // 조회하는 사람이 좋아요를 했는지 여부
 
+    private Boolean isClosed;   // 투표가 마감됐는지 여부
+
+    private List<String> theFirstItemNames;         // 1위 투표 항목 - 공동 1위 포함
+
     /**
      * 투표 게시글 Topic 객체를 Topic Response DTO 클래스로 변환하는 생성자
      * @param topic 투표 게시글 Topic 객체
      */
     public TopicResDto(Topic topic) {
-        this.topicId = topic.getTopicId();                      // 투표 게시글 ID
+        topicId = topic.getTopicId();                      // 투표 게시글 ID
         this.category = topic.getCategory().getCategoryName();  // 카테고리 
         this.title = topic.getTitle();                          // 투표 게시글 제목
         this.content = topic.getContent();                      // 투표게시글 내용
@@ -63,11 +68,17 @@ public class TopicResDto {
         this.author = topic.getMember().getNickname().getName();    // 작성자 nickname
         this.isAuthor = topic.getIsAuthor();        // 조회하는 사람이 작성자인지 여부
         this.isVoted = topic.getIsVoted();          // 조회하는 사람이 투표했는지 여부
+        isClosed = topic.isTopicClosed(LocalDateTime.now());    // 현재 시간으로부터 투표가 마감됐는지 여부 확인
 
         // TODO: 투표 게시글의 조회수
         // views
+
         likes = topic.countNumberOfTopicLike();     // 투표 게시글의 좋아요 개수
         this.isLiked = topic.getIsLiked();          // 조회하는 사람이 투표 게시글에 좋아요 했는지 여부
+
+        theFirstItemNames = new ArrayList<>();      // DTO의 1위 투표 항목 이름 리스트 생성
+        topic.findTheFirstVoteItemName();           // 투표 게시글에서 1위 투표 항목 리스트 찾기
+        theFirstItemNames.addAll(topic.getTheFirstItemNames());     // DTO의 1위 투표 항목 이름 리스트에 삽입
     }
 
     /**

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -52,6 +52,9 @@ public class Topic extends BaseTimeEntity {
     @Transient
     private Boolean isLiked;        // 조회하는 사람이 좋아요했는지 여부
 
+    @Transient
+    private List<String> theFirstItemNames;    // 1위 투표 항목
+
     @Builder
     public Topic(String title, String content, String category,
                  Member member, String closedAt) {
@@ -144,6 +147,48 @@ public class Topic extends BaseTimeEntity {
     }
 
     /**
+     * 투표 게시글의 투표가 마감됐는지 여부 확인
+     * @param now 현재 시간 LocalDateTime
+     * @return 마감됐으면 true, 마감되지않았으면 false Boolean
+     */
+    public Boolean isTopicClosed(LocalDateTime now) {
+        if (topicStatus == TopicStatus.CLOSED) {        // 투표 게시글 상태가 마감 상태이면
+            return true;
+        } else if (closedAt.isBefore(now)){      // 현재 시간으로부터 마감일이 이전이면
+            topicStatus = TopicStatus.CLOSED;           // 투표 게시글 상태를 마감 상태로 바꿈
+            return true;                                // 투표 게시글이 마감된 상태 반환
+        }
+        return false;                                   // 투표 게시글이 마감되지 않은 상태 반환
+    }
+
+    /**
+     * 투표 게시글에서 1위 투표 항목 이름 리스트 찾기
+     * @return 1위 투표 항목 이름 리스트
+     */
+    public List<String> findTheFirstVoteItemName() {
+        theFirstItemNames = new ArrayList<>();                          // 1위 투표 항목 이름 리스트 초기화
+
+        int max = topicVoteItems.get(0).findNumberOfVoteInItem();               // 최대 투표수를 첫번째 투표 항목의 투표 수로 초기화
+        for (int i = 1; i < topicVoteItems.size(); i++) {                       // 각 투표 항목들을 순회하면서
+            int nowNumber = topicVoteItems.get(i).findNumberOfVoteInItem();     // 투표 수 계산하여 최대 투표 수 찾기
+            if (max < nowNumber){
+                max = nowNumber;
+            }
+        }
+
+        if (max != 0) {     // 최대 투표수가 0이 아니면(투표를 진행했으면) - 최대 투표 수가 0이면 투표 진행 안함.
+            for (TopicVoteItem topicVoteItem : topicVoteItems) {                    // 각 투표 항목들 진행하면서
+                if (topicVoteItem.findNumberOfVoteInItem() == max) {                // 최대 투표 수와 같은 투표 항목이면
+                    theFirstItemNames.add(topicVoteItem.getTopicVoteItemName());    // 1위 투표 항목 이름 리스트에 추가
+                }
+            }
+        }
+
+        // 1위 투표 항목 이름 리스트 반환
+        return theFirstItemNames;
+    }
+
+    /**
      * 카테고리 enum 클래스
      */
     @Getter
@@ -178,7 +223,8 @@ public class Topic extends BaseTimeEntity {
      */
     public enum TopicStatus {
         ACTIVE("활성화"),
-        REMOVED("삭제된 게시글")
+        REMOVED("삭제된 게시글"),
+        CLOSED("마감된 투표 게시글")
         ;
 
         @Getter

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/TopicVoteItem.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/TopicVoteItem.java
@@ -90,4 +90,12 @@ public class TopicVoteItem extends BaseTimeEntity {
         topicVoteItemVoted = false;
         return false;
     }
+
+    /**
+     * 투표 항목의 투표 수 계산
+     * @return 투표 항목의 투표 수
+     */
+    public int findNumberOfVoteInItem() {
+        return topicVotes.size();
+    }
 }


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #111 


## 무엇이 추가 되었나요?

- Topic Entity 클래스 내 1위 투표 항목 리스트,   투표가 마감되어있는지 확인하는 메서드, 1위 투표 항목 찾는 메서드 추가
- Topic Enitity 클래스 내 TopicStatus 투표 게시글 상태에 마감된 상태 추가
- TopicPageResDto 클래스 내 투표 게시글 마감여부, 1위 투표 항목 리스트 , 생성자에 Topic에서 1위 투표 항목찾아서 DTO클래스의 리스트에 넣어주는 로직 추가
- TopicresDto 클래스에 투표가 마감는지 여부, 1위 투표 항목 리스트, 생성자에 Topic에서 1위 투표 항목찾아서 DTO 클래스의 리스트에 넣어주는 로직 추가 
- TopicVoteItem Entity 클래스내 투표 항목 수 계산하는 메서드 추가 

## 기타 정보

- 투표 게시글에 대해 1위 투표 항목 보여주는 기능 구현하였습니다.
- DTO 클래스에는 문자열 리스트로 1위 투표 항목을 반환하여 공동 1위가 있을 때 같이 반환하도록 하였습니다. 