### PR TITLE
[BE] 투표 게시글 수정 기능 API 구현  #121

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/exception/exceptionCode/ExceptionCode.java
@@ -22,6 +22,7 @@ public enum ExceptionCode {
     TOPIC_NOT_EXIST(404, "존재하지 않는 게시글 입니다."),
     FILTER_NOT_EXIST(400, "잘못된 조회 필터 입니다"),
     VOTE_ITEM_NOT_EXIST(404, "존재하지 않는 투표 항목입니다"),
+    CATEGORY_NOT_EXIST(404, "존재하지 않는 카테고리입니다")
 //    NOT_EXACT_PASSWORD(400, "비밀번호가 올바르지 않습니다.")
     ;
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -141,7 +141,6 @@ public class TopicController {
      */
     @PatchMapping("/{topic-id}/like")
     public ResponseEntity postTopicLike(@PathVariable("topic-id") long topicId,
-                                        @RequestBody TopicPatchReqDto topicPatchReqDto,
                                         HttpServletRequest request) {
 
         // 요청의 token으로부터 memberId 추출해 Member 클래스 생성
@@ -164,11 +163,13 @@ public class TopicController {
     /**
      * 투표 게시글을 수정하는 Patch 핸들러 메서드
      * @param topicId 투표 게시글 id Long
-     * @param request HttpoServletRequest 객체 - 토큰 확인용
+     * @param topicPatchReqDto 투표 게시글 수정용 DTO 클래스 TopicPatchReqDto
+     * @param request HttpServletRequest 객체 - 토큰 확인용
      * @return TopicPostResDto 클래스에 대한 Response Entity, HTTP Status 반환
      */
     @PatchMapping("/{topic-id}")
     public ResponseEntity patchTopic(@PathVariable("topic-id") long topicId,
+                                     @RequestBody TopicPatchReqDto topicPatchReqDto,
                                      HttpServletRequest request) {
 
         // 요청의 token으로부터 memberId 추출해 Member 클래스 생성
@@ -176,7 +177,7 @@ public class TopicController {
         Member member = memberService.findMember(memberId);
 
         // 투표 게시글 저장
-        Topic topic = topicService.updateTopic(topicPatchReqDto.toTopic(member));
+        Topic topic = topicService.updateTopic(topicPatchReqDto.toEntity(member), topicId);
 
         // Topic 클래스를 ResponseDTO로 변환
         TopicPostResDto topicPostResDto = new TopicPostResDto(topic.getTopicId());

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -141,6 +141,7 @@ public class TopicController {
      */
     @PatchMapping("/{topic-id}/like")
     public ResponseEntity postTopicLike(@PathVariable("topic-id") long topicId,
+                                        @RequestBody TopicPatchReqDto topicPatchReqDto,
                                         HttpServletRequest request) {
 
         // 요청의 token으로부터 memberId 추출해 Member 클래스 생성
@@ -158,5 +159,28 @@ public class TopicController {
 
         // Topic Like Response DTO 객체와 HTTPStatus 반환
         return new ResponseEntity<>(new SingleResDto<>(topicLikeResDto), HttpStatus.OK);
+    }
+
+    /**
+     * 투표 게시글을 수정하는 Patch 핸들러 메서드
+     * @param topicId 투표 게시글 id Long
+     * @param request HttpoServletRequest 객체 - 토큰 확인용
+     * @return TopicPostResDto 클래스에 대한 Response Entity, HTTP Status 반환
+     */
+    @PatchMapping("/{topic-id}")
+    public ResponseEntity patchTopic(@PathVariable("topic-id") long topicId,
+                                     HttpServletRequest request) {
+
+        // 요청의 token으로부터 memberId 추출해 Member 클래스 생성
+        Long memberId = jwtExtractUtil.extractMemberIdFromJwt(request);
+        Member member = memberService.findMember(memberId);
+
+        // 투표 게시글 저장
+        Topic topic = topicService.updateTopic(topicPatchReqDto.toTopic(member));
+
+        // Topic 클래스를 ResponseDTO로 변환
+        TopicPostResDto topicPostResDto = new TopicPostResDto(topic.getTopicId());
+
+        return new ResponseEntity<> (new SingleResDto<>(topicPostResDto), HttpStatus.OK);
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -177,7 +177,7 @@ public class TopicController {
         Member member = memberService.findMember(memberId);
 
         // 투표 게시글 저장
-        Topic topic = topicService.updateTopic(topicPatchReqDto.toEntity(member), topicId);
+        Topic topic = topicService.updateTopic(topicPatchReqDto, topicId, member);
 
         // Topic 클래스를 ResponseDTO로 변환
         TopicPostResDto topicPostResDto = new TopicPostResDto(topic.getTopicId());

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
@@ -1,5 +1,8 @@
 package TeamBigDipper.UYouBooDan.topic.dto;
 
+import TeamBigDipper.UYouBooDan.member.entity.Member;
+import TeamBigDipper.UYouBooDan.topic.entity.Topic;
+import TeamBigDipper.UYouBooDan.topic.entity.TopicVoteItem;
 import lombok.Getter;
 
 import java.util.List;
@@ -17,6 +20,35 @@ public class TopicPatchReqDto {
 
     @Getter
     public static class TopicVoteItemPatchDto {
+        private Long topicVoteItemId;           // 투표 항목 ID
         private String topicVoteItemName;       // 투표 항목 이름
+    }
+
+    /**
+     * TopicPatchReqDto 클래스를 투표 게시글 Topic Entity 클래스로 변환하는 메서드
+     * @param member 작성자 Member 클래스
+     * @return Topic Entity 클래스
+     */
+    public Topic toEntity(Member member) {
+        Topic topic = Topic.builder()
+                .title(this.title)
+                .content(this.content)
+                .category(this.category)
+                .closedAt(this.closedAt)
+                .member(member)
+                .build();
+
+        // 투표 게시글에 투표 항목 추가
+        topicVoteItems.stream()
+                .map(topicVoteItemPatchDto -> {
+                    TopicVoteItem topicVoteItem = TopicVoteItem.builder()
+                            .topicVoteItemId(topicVoteItemPatchDto.getTopicVoteItemId())
+                            .topic(topic)
+                            .topicVoteItemName(topicVoteItemPatchDto.getTopicVoteItemName())
+                            .build();
+                    return topicVoteItem;})
+                .forEach(topicVoteItem -> topic.addTopicVoteItem(topicVoteItem));
+
+        return topic;
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
@@ -9,20 +9,23 @@ import java.util.List;
 
 /**
  * 투표 게시글 수정에 대한 Request DTO 클래스
+ * 투표 항목은 일단 수정 불가 - 추후 유지 보수하면서 나중에 대비하여 투표 항목 부분 코드 주석 처리
  */
 @Getter
 public class TopicPatchReqDto {
     private String category;                            // 카테고리
     private String title;                               // 제목
     private String content;                             // 내용
-    private String closedAt;                            // 마감일
-    private List<TopicVoteItemPatchDto> topicVoteItems; // 투표 항목
+//    private List<TopicVoteItemPatchDto> topicVoteItems; // 투표 항목
 
-    @Getter
-    public static class TopicVoteItemPatchDto {
-        private Long topicVoteItemId;           // 투표 항목 ID
-        private String topicVoteItemName;       // 투표 항목 이름
-    }
+    /**
+     * 투표 항목 Patch DTO 클래스
+     */
+//    @Getter
+//    public static class TopicVoteItemPatchDto {
+//        private Long topicVoteItemId;           // 투표 항목 ID
+//        private String topicVoteItemName;       // 투표 항목 이름
+//    }
 
     /**
      * TopicPatchReqDto 클래스를 투표 게시글 Topic Entity 클래스로 변환하는 메서드
@@ -34,20 +37,19 @@ public class TopicPatchReqDto {
                 .title(this.title)
                 .content(this.content)
                 .category(this.category)
-                .closedAt(this.closedAt)
                 .member(member)
                 .build();
 
         // 투표 게시글에 투표 항목 추가
-        topicVoteItems.stream()
-                .map(topicVoteItemPatchDto -> {
-                    TopicVoteItem topicVoteItem = TopicVoteItem.builder()
-                            .topicVoteItemId(topicVoteItemPatchDto.getTopicVoteItemId())
-                            .topic(topic)
-                            .topicVoteItemName(topicVoteItemPatchDto.getTopicVoteItemName())
-                            .build();
-                    return topicVoteItem;})
-                .forEach(topicVoteItem -> topic.addTopicVoteItem(topicVoteItem));
+//        topicVoteItems.stream()
+//                .map(topicVoteItemPatchDto -> {
+//                    TopicVoteItem topicVoteItem = TopicVoteItem.builder()
+//                            .topicVoteItemId(topicVoteItemPatchDto.getTopicVoteItemId())
+//                            .topic(topic)
+//                            .topicVoteItemName(topicVoteItemPatchDto.getTopicVoteItemName())
+//                            .build();
+//                    return topicVoteItem;})
+//                .forEach(topicVoteItem -> topic.addTopicVoteItem(topicVoteItem));
 
         return topic;
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/dto/TopicPatchReqDto.java
@@ -1,0 +1,22 @@
+package TeamBigDipper.UYouBooDan.topic.dto;
+
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 투표 게시글 수정에 대한 Request DTO 클래스
+ */
+@Getter
+public class TopicPatchReqDto {
+    private String category;                            // 카테고리
+    private String title;                               // 제목
+    private String content;                             // 내용
+    private String closedAt;                            // 마감일
+    private List<TopicVoteItemPatchDto> topicVoteItems; // 투표 항목
+
+    @Getter
+    public static class TopicVoteItemPatchDto {
+        private String topicVoteItemName;       // 투표 항목 이름
+    }
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -203,7 +203,13 @@ public class Topic extends BaseTimeEntity {
      * @return 진행중이면 true, 아니면 false Boolean 반환
      */
     public Boolean isTopicInProgress() {
-        return topicStatus == TopicStatus.PROGRESS;
+        topicVoteItems.forEach(topicVoteItem -> {               // 투표 항목 리스트 순회하면서
+            if (topicVoteItem.getTopicVotes().size() > 0) {     // 투표 기록이 있으면
+                topicStatus = TopicStatus.PROGRESS;             // 투표 게시글의 상태를 진행중으로 전환
+            }
+        });
+
+        return topicStatus == TopicStatus.PROGRESS;             // 투표 게시글 상태가 진행중인지 여부 반환
     }
 
     /**

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -214,15 +214,24 @@ public class Topic extends BaseTimeEntity {
 
     /**
      * 투표 게시글의 카테고리 수정하는 메서드
-     * @param category
+     * @param category 카테고리 Enum
      */
     public void modifyTopicCategory(Category category) {
         this.category = category;
     }
 
     /**
+     * 투표 게시글의 카테고리 수정하는 메서드
+     * @param category 카테고리 문자열 String
+     */
+    public void modifyTopicCategory(String category) {
+        this.category = Category.nameOf(category);
+
+    }
+
+    /**
      * 투표 게시글의 제목 수정하는 메서드
-     * @param title
+     * @param title 제목 String
      */
     public void modifyTopicTitle(String title) {
         this.title = title;
@@ -230,19 +239,20 @@ public class Topic extends BaseTimeEntity {
 
     /**
      * 투표 게시글의 내용 수정하는 메서드
-     * @param title
+     * @param content 내용 String
      */
-    public void modifyTopicContent(String title) {
+    public void modifyTopicContent(String content) {
         this.content = content;
     }
 
     /**
      * 투표 게시글의 마감일 수정하는 메서드
+     * 마감일은 일단 수정 불가로 정함 - 나중에 기능 추가시 대비하여 코드 주석 처리
      * @param closedAt
      */
-    public void modifyTopicClosedAt(LocalDateTime closedAt) {
-        this.closedAt = closedAt;
-    }
+//    public void modifyTopicClosedAt(LocalDateTime closedAt) {
+//        this.closedAt = closedAt;
+//    }
 
     /**
      * 카테고리 enum 클래스

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -1,6 +1,8 @@
 package TeamBigDipper.UYouBooDan.topic.entity;
 
 import TeamBigDipper.UYouBooDan.global.auditing.BaseTimeEntity;
+import TeamBigDipper.UYouBooDan.global.exception.dto.BusinessLogicException;
+import TeamBigDipper.UYouBooDan.global.exception.exceptionCode.ExceptionCode;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
 import lombok.Builder;
 import lombok.Getter;
@@ -189,6 +191,54 @@ public class Topic extends BaseTimeEntity {
     }
 
     /**
+     * 투표 게시글이 삭제됐는지 여부 반환하는 메서드
+     * @return 삭제됐으면 true, 아니면 false Boolean 반환
+     */
+    public Boolean isTopicRemoved(){
+        return topicStatus == TopicStatus.REMOVED;
+    }
+
+    /**
+     * 투표 게시글의 투표가 진행중인지 여부 반환하는 메서드
+     * @return 진행중이면 true, 아니면 false Boolean 반환
+     */
+    public Boolean isTopicInProgress() {
+        return topicStatus == TopicStatus.PROGRESS;
+    }
+
+    /**
+     * 투표 게시글의 카테고리 수정하는 메서드
+     * @param category
+     */
+    public void modifyTopicCategory(Category category) {
+        this.category = category;
+    }
+
+    /**
+     * 투표 게시글의 제목 수정하는 메서드
+     * @param title
+     */
+    public void modifyTopicTitle(String title) {
+        this.title = title;
+    }
+
+    /**
+     * 투표 게시글의 내용 수정하는 메서드
+     * @param title
+     */
+    public void modifyTopicContent(String title) {
+        this.content = content;
+    }
+
+    /**
+     * 투표 게시글의 마감일 수정하는 메서드
+     * @param closedAt
+     */
+    public void modifyTopicClosedAt(LocalDateTime closedAt) {
+        this.closedAt = closedAt;
+    }
+
+    /**
      * 카테고리 enum 클래스
      */
     @Getter
@@ -214,7 +264,7 @@ public class Topic extends BaseTimeEntity {
                     return category;
                 }
             }
-            return null;
+            throw new BusinessLogicException(ExceptionCode.CATEGORY_NOT_EXIST);
         }
     }
 
@@ -224,7 +274,8 @@ public class Topic extends BaseTimeEntity {
     public enum TopicStatus {
         ACTIVE("활성화"),
         REMOVED("삭제된 게시글"),
-        CLOSED("마감된 투표 게시글")
+        CLOSED("마감된 투표 게시글"),
+        PROGRESS("투표가 진행 중인 게시글")
         ;
 
         @Getter

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/TopicVoteItem.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/TopicVoteItem.java
@@ -37,12 +37,14 @@ public class TopicVoteItem extends BaseTimeEntity {
     /**
      * TopicVoteItem 객체 생성자
      * @param topic 투표 게시글 Topic 객체
-     * @param topicVoteItemName 투표 항목이름 String 객체
+     * @param topicVoteItemName 투표 항목 이름 String 객체
+     * @param topicVoteItemId 투표 항목 Id Long 객체
      */
     @Builder
-    public TopicVoteItem(Topic topic, String topicVoteItemName) {
+    public TopicVoteItem(Topic topic, String topicVoteItemName, Long topicVoteItemId) {
         this.topic = topic;
         this.topicVoteItemName = topicVoteItemName;
+        this.topicVoteItemId = topicVoteItemId;
         topicVotes = new ArrayList<>();
     }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
@@ -3,6 +3,7 @@ package TeamBigDipper.UYouBooDan.topic.service;
 import TeamBigDipper.UYouBooDan.global.exception.dto.BusinessLogicException;
 import TeamBigDipper.UYouBooDan.global.exception.exceptionCode.ExceptionCode;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
+import TeamBigDipper.UYouBooDan.topic.dto.TopicPatchReqDto;
 import TeamBigDipper.UYouBooDan.topic.entity.Topic;
 import TeamBigDipper.UYouBooDan.topic.entity.TopicLike;
 import TeamBigDipper.UYouBooDan.topic.entity.TopicVote;
@@ -224,46 +225,47 @@ public class TopicService {
         return topicLikeRepository.save(topicLike);     // TopicLike 저장 후 반환
     }
 
-    public Topic updateTopic(Topic requestedTopic, Long topicId) {
+    /**
+     * 투표 게시글 수정하는 메서드
+     * @param topicPatchReqDto 투표 게시글 수정 Patch Dto 클래스
+     * @param topicId 투표 게시글 Id Long
+     * @param member 사용자 Member
+     * @return 수정된 투표 게시글 Topic
+     */
+    public Topic updateTopic(TopicPatchReqDto topicPatchReqDto, Long topicId, Member member) {
 
         Topic verifiedTopic = findVerifiedTopic(topicId);                           // 유효한 투표 게시글인지 확인
 
-        verifyTopicAuthor(verifiedTopic, requestedTopic.getMember());               // 투표 게시글의 작성자인지 확인
+        verifyTopicAuthor(verifiedTopic, member);               // 투표 게시글의 작성자인지 확인
 
         // 요청 받은 TopicEntity 클래스 차례대로 확인하면서 투표 게시글 수정 진행
-        Optional.ofNullable(requestedTopic.getCategory())           // 카테고리 수정
+        Optional.ofNullable(topicPatchReqDto.getCategory())           // 카테고리 수정
                 .ifPresent(verifiedTopic::modifyTopicCategory);
-        Optional.ofNullable(requestedTopic.getTitle())              // 제목 수정
+        Optional.ofNullable(topicPatchReqDto.getTitle())              // 제목 수정
                 .ifPresent(verifiedTopic::modifyTopicTitle);
-        Optional.ofNullable(requestedTopic.getContent())            // 내용 수정
+        Optional.ofNullable(topicPatchReqDto.getContent())            // 내용 수정
                 .ifPresent(verifiedTopic::modifyTopicContent);
-        Optional.ofNullable(requestedTopic.getClosedAt())           // 마감일 수정
-                .ifPresent(verifiedTopic::modifyTopicClosedAt);
 
-        // 투표가 이미 진행된 투표 게시글은 투표 항목 수정 불가
-        if (!verifiedTopic.isTopicInProgress()) {     // 투표가 진행 중인 게시글이 아니라면 투표 항목 수정 가능
-            Optional<List<TopicVoteItem>> optionalTopicVoteItems =
-                    Optional.ofNullable(requestedTopic.getTopicVoteItems());      // 요청 받은 투표 항목 Optional 리스트
-            if(optionalTopicVoteItems.isPresent()) {                                    // 요청 받은 투표 항목 Optional 리스트가 존재하면
-                List<TopicVoteItem> topicVoteItems = optionalTopicVoteItems.get();      // 요청 받은 투표 항목 Optional 리스트를 엔티티 리스트로 변환
-
-                // 투표 항목 엔티티 리스트 순회하면서 투표 항목 존재 여부 확인 및 값 수정
-                for (TopicVoteItem topicVoteItem: topicVoteItems) {
-                    Long topicVoteItemId = topicVoteItem.getTopicVoteItemId();
-//                    if (Object.isNull(topicVoteItemId)) {
+        // 투표 항목 수정 불가 - 투표 항목 수정 부분은 일단 주석 처리. 나중에 기능 추가시 대비하여 주석 처리
+//        // 투표가 이미 진행된 투표 게시글은 투표 항목 수정 불가
+//        if (!verifiedTopic.isTopicInProgress()) {     // 투표가 진행 중인 게시글이 아니라면 투표 항목 수정 가능
+//            Optional<List<TopicVoteItem>> optionalTopicVoteItems =
+//                    Optional.ofNullable(requestedTopic.getTopicVoteItems());      // 요청 받은 투표 항목 Optional 리스트
+//            if(optionalTopicVoteItems.isPresent()) {                                    // 요청 받은 투표 항목 Optional 리스트가 존재하면
+//                List<TopicVoteItem> topicVoteItems = optionalTopicVoteItems.get();      // 요청 받은 투표 항목 Optional 리스트를 엔티티 리스트로 변환
 //
-//                    }
-                    TopicVoteItem verifiedTopicVoteItem = findVerifiedTopicVoteItem(topicVoteItem.getTopicVoteItemId());
-
-                }
-
+//                // 투표 항목 엔티티 리스트 순회하면서 투표 항목 존재 여부 확인 및 값 수정
+//                for (TopicVoteItem topicVoteItem: topicVoteItems) {
+//                    Long topicVoteItemId = topicVoteItem.getTopicVoteItemId();
+//                    TopicVoteItem verifiedTopicVoteItem = findVerifiedTopicVoteItem(topicVoteItem.getTopicVoteItemId());
+//
+//                }
 //                deleteTopicVoteItemInTopic(verifiedTopic);      // 기존의 투표 항목들 Repository 에서 삭제
 //                verifiedTopic.clearTopicVoteItems();            // 투표 게시글의 투표 항목 삭제
-
 //                List<TopicVoteItem> topicVoteItems = optionalTopicVoteItems.get();      // Optional 리스트를 TopicVoteItem 리스트로 변환
-                topicVoteItems.forEach(verifiedTopic::addTopicVoteItem);        // 투표 게시글에 투표 항목 넣음
-            }
-        }
+//                topicVoteItems.forEach(verifiedTopic::addTopicVoteItem);        // 투표 게시글에 투표 항목 넣음
+//            }
+//        }
 
         return topicRepository.save(verifiedTopic);     // 레포지토리에 Topic 객체 저장 후 반환
     }


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #121 


## 무엇이 추가 되었나요?

- Topic 클래스에 카테고리 수정하는 modifyTopicCategory 메서드에서 인자를 문자열로도 받는 메서드 오버로딩해서 추가
- Topic 클래스에 Category Enum인 투표 게시글 카테고리 수정하는 modifyTopicCategory 메서드 주석 변경
- Topic 클래스에 modifyTopicTitle 메서드 주석 변경
- Topic 클래스에 투표 게시글 마감일 수정하는 modifyTopicClosedAt 메서드 주석 처리
- TopicController 클래스의 patchTopic 메서드 내 updateTopic메서드의 인자 변경
- TopicPatchDto 클래스내 투표 항목 수정 불가로 인해 투표 항목 수정 관련 로직 주석 처리
- TopicService 클래스내 투표 항목 수정 불가로 인해 투표 항목 수정 관련 로직 주석 처리
- TopicService 클래스내 마감일 수정 불가로 마감일 수정 관련 코드 제거

## 기타 정보
- 투표 항목은 수정 불가로 정하여 나중에 기능 추가할 경우 대비해서 주석 처리하였습니다. 
- 투표 게시글의 제목, 카테고리, 내용 수정할 수 있도록 기능을 구현하였습니다.
- 수정하고 싶은 부분만 채워서 보낼 수 있습니다. 
