### PR TITLE
[BE] 투표 게시글 삭제하는 기능 API 구현 #128

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/controller/TopicController.java
@@ -187,4 +187,22 @@ public class TopicController {
 
         return new ResponseEntity<> (new SingleResDto<>(topicPostResDto), HttpStatus.OK);
     }
+
+    /**
+     * 투표 게시글 삭제하는 핸들러 메서드
+     * @param topicId 삭제할 투표 게시글 id long
+     * @param request HttpServletReqeust 객체 - 토큰 확인용
+     * @return 성공적으로 삭제됐다는 메세지를 포함한 Response Entity, HTTP Status 반환
+     */
+    @DeleteMapping("/{topic-id}")
+    public ResponseEntity deleteTopic(@PathVariable("topic-id") long topicId,
+                                      HttpServletRequest request) {
+        // 요청의 token으로부터 memberId 추출해 Member 클래스 생성
+        Long memberId = jwtExtractUtil.extractMemberIdFromJwt(request);
+        Member member = memberService.findMember(memberId);
+
+        topicService.deleteTopic(topicId, member);      // Service 클래스에서 투표 게시글 삭제
+
+        return new ResponseEntity<>(new SingleResDto<>("투표 게시글이 성공적으로 삭제 되었습니다."), HttpStatus.OK);
+    }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
@@ -272,6 +272,21 @@ public class TopicService {
     }
 
     /**
+     * 투표 게시글 삭제하는 메서드
+     * @param topicId 삭제할 투표 게시글 id long
+     * @param member 삭제를 요청하는 사용자 member
+     */
+    public void deleteTopic(long topicId, Member member) {
+        Topic verifiedTopic = findVerifiedTopic(topicId);       // 유효한 투표 게시글인지 확인
+
+        verifyTopicAuthor(verifiedTopic, member);               // 요청하는 사용자가 작성자인지 확인
+
+        verifiedTopic.changeTopicStatusRemoved();               // 투표 게시글의 상태를 삭제 상태로 변환
+
+        topicRepository.save(verifiedTopic);             // 투표 게시글을 Repository에 저장
+    }
+
+    /**
      *투표 게시글에 좋아요 개수 세기
      * @param topicId  투표게시글 id Long
      * @return 투표 게시글 좋아요 개수 long


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #128 


## 무엇이 추가 되었나요?

- TopicController 클래스에 투표 게시글 삭제하는 deleteTopic메서드 추가
- TopicService클래스에 투표 게시글 삭제하는 deleteTopic메서드 추가 

## 기타 정보

- 투표게시글을 실제로는 삭제하지 않고 투표 게시글의 상태를 삭제된 상태로 바꾸어서 Repository에 저장합니다.