### PR TITLE
[BE] Naver 로그인 API 기본 Handler 작성, Security Member Global의 불필요한 주석 리팩토링, yml 내 pagenation 디폴트값 설정 추가

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/auditing/BaseTimeEntity.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/auditing/BaseTimeEntity.java
@@ -19,7 +19,6 @@ import java.time.LocalDateTime;
  *             으로 필드를 구현해 주시면 됩니다.
  *
  */
-
 @Getter
 @Setter
 @MappedSuperclass

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -1,0 +1,85 @@
+package TeamBigDipper.UYouBooDan.global.oauth2.naver;
+
+import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
+import TeamBigDipper.UYouBooDan.global.security.util.JwtExtractUtil;
+import TeamBigDipper.UYouBooDan.member.service.MemberService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.URLEncoder;
+import java.security.SecureRandom;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/naver")
+public class NaverOauthController {
+
+    // application-local.yml 파일에 관련 프로퍼티를 입력해야 정상 동작하므로, 우선 주석처리해둠
+//    @Getter
+//    @Value("${oauth.naver.clientId}")
+//    private String naverClientId;
+
+    private final MemberService memberService;
+    private final JwtTokenizer jwtTokenizer;
+    private final JwtExtractUtil jwtExtractUtil;
+
+    /**
+     * 프론트에 Redirect URI를 제공하기 위한 메소드
+     * 프론트에서 네이버 인증 센터로 요청을 주기위한 URI를 제공하며, 이를통해 인증코드를 받아 자체 서비스 callback API 호출시 전달
+     * @return redirect URI
+     * @throws UnsupportedEncodingException
+     */
+    @GetMapping("/oauth")
+    public ResponseEntity<?> naverConnect() throws UnsupportedEncodingException {
+        StringBuffer url = new StringBuffer();
+
+        // 카카오 API 명세에 맞춰서 작성
+        String redirectURI = URLEncoder.encode("http://www.localhost:8080", "UTF-8"); // redirectURI 설정 부분
+        SecureRandom random = new SecureRandom();
+        String state = new BigInteger(130, random).toString();
+
+        url.append("https://nid.naver.com/oauth2.0/authorize?response_type=code");
+//        url.append("&client_id=" + getNaverClientId());
+        url.append("&redirect_uri=" + redirectURI); // getRedirectUri());
+        url.append("&state=" + state);
+
+        return new ResponseEntity<>(url.toString(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소
+    }
+
+
+    /**
+     * 실제 로그인 로직을 수행할 메소드
+     * @return
+     */
+    @GetMapping("/callback")
+    public String naverLogin() {
+
+        // 네이버 로그인 콜백 로직
+
+        return "Success Logout: User";
+    }
+
+
+    /**
+     * 로그아웃 API
+     * @param request
+     * @return
+     */
+    @GetMapping("/logout")
+    public ResponseEntity<?> naverLogout(HttpServletRequest request) {
+
+        // 로그아웃 로직 작성
+
+        return new ResponseEntity<>("Success Logout: User", HttpStatus.OK);
+    }
+
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/SecurityConfiguration.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/SecurityConfiguration.java
@@ -16,8 +16,6 @@ import org.springframework.security.crypto.factory.PasswordEncoderFactories;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
-import static org.springframework.security.config.Customizer.withDefaults;
-
 @RequiredArgsConstructor
 @EnableWebSecurity
 @Configuration

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/webConfig.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/config/webConfig.java
@@ -10,7 +10,6 @@ public class webConfig implements WebMvcConfigurer {
     /**
      * "http://localhost:3000" : 브라우저용 (www붙이면 CORS 발생)
      * "http://www.localhost:3000" : 카카오 리다이렉션용 (WWW 안붙이면 카카오에서 등록이 안됨)
-     *
      */
     @Override
     public void addCorsMappings (CorsRegistry registry) {

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/FilterExceptionResolver.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/FilterExceptionResolver.java
@@ -16,8 +16,6 @@ public class FilterExceptionResolver {
 
     /**
      * 인증에러 발생 시 예외 핸들러 메소드. 만약 인증에러가 아니면, 다른 에러에 대한 메세지를 로그와 예외로 던짐
-     * @param e
-     * @param response
      */
     @SneakyThrows
     public void handleException (RuntimeException e, HttpServletResponse response) {
@@ -39,8 +37,6 @@ public class FilterExceptionResolver {
 
     /**
      * 에러 상태 반환 메소드
-     * @param response
-     * @param exceptionCode
      */
     @SneakyThrows
     private void sendErrorResponse (HttpServletResponse response, ExceptionCode exceptionCode) {

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtAuthenticationFilter.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtAuthenticationFilter.java
@@ -75,7 +75,6 @@ public class JwtAuthenticationFilter extends UsernamePasswordAuthenticationFilte
         String refreshToken = jwtTokenizer.delegateRefreshToken(authenticatedMember);
         response.setHeader("Authorization", "Bearer " + accessToken);
 
-        // refreshToken responseCookie builder 방식
         ResponseCookie cookie = ResponseCookie.from("refreshToken",refreshToken)
 //                .maxAge(7*24*60*60)
                 .path("/")

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/controller/MemberController.java
@@ -35,9 +35,6 @@ public class MemberController {
      */
     @PostMapping
     public ResponseEntity<SingleResDto<Long>> postMember (@RequestBody MemberPostReqDto memberPostReqDto) {
-        /**
-         * 추후 시큐리티 구현 후 member password 암호화 예정
-         */
         Member savedMember = memberService.createMember(memberPostReqDto.toEntity());
 
         return new ResponseEntity<>(new SingleResDto<>(savedMember.getMemberId()), HttpStatus.CREATED);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPatchReqDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/dto/MemberPatchReqDto.java
@@ -12,7 +12,7 @@ public class MemberPatchReqDto {
     private String password;
     private String nickname;
     private String profile;
-    private Member.MemberStatus memberStatus; // MemberStatus의 에러 해결 후 활성화 예정입니다.
+    private Member.MemberStatus memberStatus;
 
     /**
      * 밸류지정방식
@@ -22,7 +22,7 @@ public class MemberPatchReqDto {
                 .password(this.password)
                 .nickname(new Name(this.nickname))
                 .profile(new Photo(this.profile))
-                .memberStatus(this.memberStatus) // MemberStatus의 에러 해결 후 활성화 예정입니다.
+                .memberStatus(this.memberStatus)
                 .build();
         return member;
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -28,7 +28,7 @@ public class Member extends BaseTimeEntity {
     private String email;
 
     @Setter
-    private String password; // 컨트롤러에서 암호화 할 예정
+    private String password;
 
     @Embedded
     private Name nickname;

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -24,9 +24,6 @@ import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 
-/**
- * Entity 타입을 확인하기위해 서비스 로직을 작성했습니다.
- */
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 @Service
@@ -41,13 +38,7 @@ public class MemberService {
     @Value("${oauth.kakao.initialKey}")
     private String initialKey;
 
-    /**
-     * 예시 코드
-     * memberId는 DB 연동 후 조회가 가능합니다.
-     *
-     * @param member : 객체명
-     * @return : 객체명 (식별자 반환을 위함)
-     */
+
     @Transactional
     public Member createMember(Member member) {
         verifyNotExistEmail(member.getEmail());
@@ -94,6 +85,7 @@ public class MemberService {
         Member verifyMember = new Member().verifyMember(memberRepository.findById(memberId));
         memberRepository.delete(verifyMember);
     }
+
 
     /**
      * Member Entity클래스 내 구현한 회원탈퇴 메소드(withdrawMember 호출)
@@ -145,8 +137,6 @@ public class MemberService {
 
     /**
      * 이메일 중복 확인 메소드. 이메일 존재시 예외 발생
-     *
-     * @param email
      */
     public void verifyNotExistEmail(String email) {
         Optional<Member> optionalEmail = memberRepository.findByEmail(email);
@@ -154,10 +144,8 @@ public class MemberService {
     }
 
 
-    // 수정이 필요한 메소드 입니다.
     /**
      * 닉네임 중복확인 메소드. 닉네임 존재시 예외 발생
-     *
      * @param nickname
      */
     public void verifyNotExistNickname(String nickname) {
@@ -224,7 +212,7 @@ public class MemberService {
                     .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
                     .build();
 
-            if(googleProfile.getEmail()==null) member.modifyEmail(googleProfile.getSub()+"@uyouboodan.com"); // email 수집 미동의시, 자사 email로 가입됨
+            if(googleProfile.getEmail()==null) member.modifyEmail(googleProfile.getSub()+"@uyouboodan.com");
             else member.modifyEmail(googleProfile.getEmail());
 
             if(googleProfile.getPicture()!=null) member.modifyProfile(new Photo(googleProfile.getPicture()));

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/memberInfo/dto/MemberTopicResDto.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/memberInfo/dto/MemberTopicResDto.java
@@ -15,7 +15,7 @@ public class MemberTopicResDto extends BaseTimeEntity {
     private String title;
     private String content;
     private String nickname;
-    private String bestVote;  // 현재는 null반환, 추후 TopicVote구현 완료 후 값이 할당될 예정
+    private String bestVote;
 
     public MemberTopicResDto(Topic topic) {
         this.topicId = topic.getTopicId();

--- a/BE/UYouBooDan/src/main/resources/application.yml
+++ b/BE/UYouBooDan/src/main/resources/application.yml
@@ -26,7 +26,9 @@ spring:
   data:
     web:
       pageable:
+        default-page-size: 20
         one-indexed-parameters: true
+
   redis:
     host: localhost
     port: 6379


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [ ] 커밋 메시지가 정책을 따르나요?
- [ ] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: Feat#144


## 무엇이 추가 되었나요?

- Naver 로그인 API 기본 Handler 작성
- Security Member Global의 불필요한 주석 리팩토링
- yml 내 pagenation 디폴트값 설정 추가 : 우선 페이지 모델링을 위해 1회 요청당 20개로 지정해두었습니다.

## 기타 정보
- Naver 로그인 관련 local.yml 설정 및 API 구현 완성은 이후 작업에서 PR 올리겠습니다.
- Security 내 권한부여 관련 설정은 추후 리팩토링 하겠습니다.
- AccessToken의 유효기간 변경 희망시 local.yml 혹은 server.yml에서 다음 부분의 시간 설정을 변경하시면 됩니다.
 (단위는 minute입니다)
jwt:
  key:
    secret: ${JWT_SECRET_KEY}
    access-token-expiration-minutes: 1440   #이 부분 : 1440 = 24 * 60 * 60
    refresh-token-expiration-minutes: 1440