### PR TITLE
[BE] 카테고리별로 전체/진행 중인/마감 임박/종료된 투표 게시글 조회 기능 구현 #115 (#177)

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/entity/Topic.java
@@ -259,33 +259,38 @@ public class Topic extends BaseTimeEntity {
      */
     @Getter
     public enum Category {
-        Food("음식"),
-        GENERAL("일반"),
-        FASHIONBEAUTY("패션뷰티"),
-        SHOPPING("쇼핑"),
-        PET("반려동물"),
-        HOBBYEXERCISE("취미운동")
+        Food("음식", "FOOD"),
+        GENERAL("일반", "GENERAL"),
+        FASHIONBEAUTY("패션뷰티", "FASHIONBEAUTY"),
+        SHOPPING("쇼핑", "SHOPPING"),
+        PET("반려동물", "PET"),
+        HOBBYEXERCISE("취미운동", "HOBBYEXERCISE")
         ;
 
         @Getter
-        private String categoryName;
+        private String categoryName;        // 카테고리 한글 이름
 
-        Category(String categoryName) {
+        @Getter
+        private String categoryEngName;     // 카테고리 영어 이름
+
+        Category(String categoryName, String categoryEngName) {
             this.categoryName = categoryName;
+            this.categoryEngName = categoryEngName;
         }
 
         /**
-         * 한글로된 카테고리 이름을 Category Enum 으로 변경
-         * @param categoryName 한글로된 카테고리 이름
-         * @return Category Enum
+         * 한글 또는 영어 문자열의 카테고리 이름을 Category Enum 으로 변경
+         * @param categoryName 한글 또는 영어로된 카테고리 이름 문자열
+         * @return 카테고리 Category Enum 객체
          */
         public static Category nameOf(String categoryName) {
             for (Category category : Category.values()) {
-                if (category.getCategoryName().equals(categoryName)){
+                // 카테고리 enum의 한글 이름 값 또는 영어 이름값과 같으면
+                if (category.getCategoryName().equals(categoryName) || category.getCategoryEngName().equals(categoryName)){
                     return category;
                 }
             }
-            throw new BusinessLogicException(ExceptionCode.CATEGORY_NOT_EXIST);
+            throw new BusinessLogicException(ExceptionCode.CATEGORY_NOT_EXIST);     // 유효한 카테고리가 아니라는 Exception 반환
         }
     }
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/repository/TopicRepository.java
@@ -63,4 +63,53 @@ public interface TopicRepository extends JpaRepository<Topic, Long> {
     @Query(value = "SELECT * FROM Topic WHERE MEMBER_ID =:memberId ORDER BY createdAt DESC", nativeQuery = true)
     Page<Topic> findAllByMemberIdOrderByCreatedAtDesc(@Param("memberId") Long memberId, Pageable pageable);
 
+    /**
+     * 카테고리에 해당하는 투표 게시글 목록을 pagination을 이용해여 작성날짜 역순으로 조회
+     * @param category Topic엔티티의 Category Enum 객체 : 조회하고자 하는 투표게시글의 카테고리
+     * @param pageable Pageable 객체
+     * @return Pagiantion 적용된 Page Topic 객체 : 카테고리에 해당하는 투표 게시글 목록
+     */
+    Page<Topic> findByCategoryOrderByCreatedAtDesc(Topic.Category category, Pageable pageable);
+
+    /**
+     * 카테고리에 해당하는 진행 중인 투표 게시글 목록을 Pagination을 적용해서 작성일 내림차순으로 조회
+     * @param category Topic엔티티의 Category Enum 객체 : 조회하고자 하는 투표 게시글의 카테고리
+     * @param now 현재날짜 : LocalDateTime 객체
+     * @param pageable Pagination 객체
+     * @return Pagination 적용된 Page Topic 객체 : 카테고리에 해당하는 투표 게시글 목록
+     */
+    Page<Topic> findByCategoryAndClosedAtIsAfterOrderByCreatedAtDesc(Topic.Category category, LocalDateTime now, Pageable pageable);
+
+    /**
+     * 카테고리에 해당하는 마감 임박 투표 게시글 목록을 Pagination을 적용해서 현재날짜와 마감임박까지 마감일 오름차순으로 조회
+     * @param category Topic엔티티의 Category Enum 객체 : 조회하고자 하는 투표 게시글의 카테고리
+     * @param start 현재 날짜 : LocalDateTime 객체
+     * @param end 현재 날짜로부터 마감임박 제한 날짜 : LocalDateTime 객체
+     * @param pageable Pagination 객체
+     * @return Pagination 적용된 Page Topic 객체 : 카테고리에 해당하는 투표 게시글 목록
+     */
+    Page<Topic> findByCategoryAndClosedAtBetweenOrderByClosedAtAsc(Topic.Category category, LocalDateTime start, LocalDateTime end, Pageable pageable);
+
+    /**
+     * 카테고리에 해당하는 진행 중인 투표 게시글 중에서 추천이 많이 된 게시글 목록을 추천 수 내림차순으로 조회
+     * @param category Topic엔티티의 Category Enum 객체 : 조회하고자 하는 투표 게시글의 카테고리
+     * @param pageable Pagination 객체
+     * @return Pagination이 적용된 Page Topic 객체 : 카테고리에 해당하는 투표 게시글 목록
+     */
+    @Query(value = "SELECT t " +
+            "FROM Topic t, TopicLike l " +
+            "where l.topicLikeStatus = 1 and t.id = l.topic.id and t.topicStatus IN ('ACTIVE', 'PROGRESS') and t.category = :category " +
+            "GROUP BY l.topic.id " +
+            "ORDER BY COUNT(l.member.id) desc")
+    Page<Topic> findByCategoryAndHot(@Param("category") Topic.Category category, Pageable pageable);
+
+    /**
+     * 카테고리별로 투표 마감된 투표 게시글 목록을 Pagination을 적용해서 작성일 내림차순으로 조회
+     * @param category Topic엔티티의 Category Enum 객체 : 조회하고자 하는 투표 게시글의 카테고리
+     * @param now 현재 날짜 : LocalDateTime 객체
+     * @param pageable Pagination 객체
+     * @return Pagination이 적용된 Page Topic 객체 : 카테고리에 해당하는 투표 게시글 목록
+     */
+    Page<Topic> findByCategoryAndClosedAtIsBeforeOrderByCreatedAtDesc(Topic.Category category, LocalDateTime now, Pageable pageable);
+
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/topic/service/TopicService.java
@@ -99,25 +99,43 @@ public class TopicService {
         // 투표 게시글 마감 시간 - 현재 시간으로부터 투표 게시글 마감 임박까지 시간을 더함
         LocalDateTime end = LocalDateTime.now().plusHours(imminentHour);
 
-        // 문자열로 된 topicFilter를 enum으로 변경 후 해당 Filter enum에 맞게 리턴
-        switch(TopicFilter.nameOf(topicFilter)) {
-            // 투표 게시글 전체 목록 조회
-            case ALL:
-                break;
-            // 진행 중인 투표 게시글 목록 조회 - 작성일 기준 내림차순, 페이지네이션 적용
-            case PROGRESS:
-                return topicRepository.findAllByClosedAtIsAfterOrderByCreatedAtDesc(now, pageable);
-            // 마감 임박 투표 게시글 목록 조회
-            case IMMINENT:
-                return topicRepository.findAllByClosedAtBetweenOrderByClosedAtAsc(now, end, pageable);
-            // 전체 진행 중인 게시글 중 핫토픽 조회
-            case HOT:
-                return topicRepository.findAllByHot(pageable);
-            // 투표 마감된 투표 게시글 목록 조회
-            case CLOSED:
-                return topicRepository.findAllByClosedAtIsBeforeOrderByCreatedAtDesc(now, pageable);
-        }
+        if (topicCategory != null) {    // 카테고리 문자열이 null 아니면 - 카테고리가 존재한다면
+            // Category Enum 클래스내 카테고리 이름 확인하는 메서드로 확인 후 해당 카테고리 문자열 반환
+            Topic.Category verifiedTopicCategory = Topic.Category.nameOf(topicCategory.toUpperCase());
 
+            // 문자열로 된 topicFilter를 enum으로 변경 후 해당 Filter enum에 맞게 리턴
+            switch(TopicFilter.nameOf(topicFilter)) {
+                case ALL:           // 유효한 카테고리의 투표 게시글 전체 목록 조회
+                    return topicRepository.findByCategoryOrderByCreatedAtDesc(verifiedTopicCategory, pageable);
+                case PROGRESS:      // 카테고리별로 진행 중인 투표 게시글 목록 조회 - 작성일 기준 내림차순, 페이지네이션 적용
+                    return topicRepository.findByCategoryAndClosedAtIsAfterOrderByCreatedAtDesc(verifiedTopicCategory, now, pageable);
+                case IMMINENT:      // 카테고리별로 마감 임박 투표 게시글 목록 조회
+                    return topicRepository.findByCategoryAndClosedAtBetweenOrderByClosedAtAsc(verifiedTopicCategory, now, end, pageable);
+                case HOT:           // 카테고리별로 전체 진행 중인 게시글 중 핫토픽 조회
+                    return topicRepository.findByCategoryAndHot(verifiedTopicCategory, pageable);
+                case CLOSED:        // 카테고리별로 투표 마감된 투표 게시글 목록 조회
+                    return topicRepository.findByCategoryAndClosedAtIsBeforeOrderByCreatedAtDesc(verifiedTopicCategory, now, pageable);
+            }
+        } else {
+            // 문자열로 된 topicFilter를 enum으로 변경 후 해당 Filter enum에 맞게 리턴
+            switch(TopicFilter.nameOf(topicFilter)) {
+                // 투표 게시글 전체 목록 조회
+                case ALL:
+                    break;
+                // 진행 중인 투표 게시글 목록 조회 - 작성일 기준 내림차순, 페이지네이션 적용
+                case PROGRESS:
+                    return topicRepository.findAllByClosedAtIsAfterOrderByCreatedAtDesc(now, pageable);
+                // 마감 임박 투표 게시글 목록 조회
+                case IMMINENT:
+                    return topicRepository.findAllByClosedAtBetweenOrderByClosedAtAsc(now, end, pageable);
+                // 전체 진행 중인 게시글 중 핫토픽 조회
+                case HOT:
+                    return topicRepository.findAllByHot(pageable);
+                // 투표 마감된 투표 게시글 목록 조회
+                case CLOSED:
+                    return topicRepository.findAllByClosedAtIsBeforeOrderByCreatedAtDesc(now, pageable);
+            }
+        }
         // 페이지네이션 처리된 투표 게시글 전체 목록을 작성일 내림차순으로 정렬한 Tage<Topic> 반환
         return topicRepository.findAllByOrderByCreatedAtDesc(pageable);
     }


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [ ] 커밋 메시지가 정책을 따르나요?
- [ ] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #115 


## 무엇이 추가 되었나요?

- 카테고리별로 전체/진행 중인/마감임박/종료된 투표 게시글 조회 기능 추가

## 기타 정보

- GET /topics로 조회요청시 query parameter로 category= 으로 카테고리별로 투표게시글 조회가능합니다 (ex. category=food) 
- 카테고리 종류에는 음식 food, 일반 general, 패션뷰티 fashionbeauty, 쇼핑 shopping, 반려동물 pet, 취미운동 hobbyexercise가 있습니다. 