### PR TITLE
[BE] 네이버 로그아웃 API 구현 Feat#182

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -152,7 +152,7 @@ public class KakaoOauthController {
         userHttpHeaders.add("Authorization", "Bearer " + loginMember.getOauthAccessToken());  // "KakaoAk " + getKakaoAppKey());
         userHttpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         params.add("target_id_type", "user_id");
-        params.add("target_id", loginMember.getOauthId().toString());
+        params.add("target_id", loginMember.getOauthId());
 
         try {
             ResponseEntity<String> LogoutResponse = restTemplate.exchange(

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -180,14 +180,12 @@ public class NaverOauthController {
         userHttpHeaders.add("Authorization", "Bearer " + loginMember.getOauthAccessToken());
         userHttpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
         params.add("target_id_type", "user_id");
-        params.add("target_id", loginMember.getOauthId().toString());  // 여기서 nullpointer발생
-
-        System.out.println("null?");
+        params.add("target_id", loginMember.getOauthId());  // 여기서 nullpointer발생
 
         // Naver인증센터에 REST API 요청
         try {
             ResponseEntity<String> LogoutResponse = restTemplate.exchange(
-                    "http://nid.naver.com/nidlogin.logout",
+                    "http://nid.naver.com/nidlogin.logout", // 네이버 developer에 따로 네이버 로그아웃이 없으므로 본 경로를 사용. 단, 이 경로를 사용할 경우 HTML 로그가 나옵니다.
                     HttpMethod.POST,
                     naverLogoutRequest,
                     String.class

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -1,5 +1,7 @@
 package TeamBigDipper.UYouBooDan.global.oauth2.naver;
 
+import TeamBigDipper.UYouBooDan.global.exception.dto.BusinessLogicException;
+import TeamBigDipper.UYouBooDan.global.exception.exceptionCode.ExceptionCode;
 import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
 import TeamBigDipper.UYouBooDan.global.security.util.JwtExtractUtil;
 import TeamBigDipper.UYouBooDan.member.entity.Member;
@@ -150,6 +152,7 @@ public class NaverOauthController {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("RefreshToken", refreshToken);
 
+        System.out.println(accessToken);
         return "Success Login: User";
     }
 
@@ -162,7 +165,38 @@ public class NaverOauthController {
     @GetMapping("/logout")
     public ResponseEntity<?> naverLogout(HttpServletRequest request) {
 
-        // 로그아웃 로직 작성
+        // DI를 이용해 파라미터 및 객체를 구하는 구간
+        Long memberId = jwtExtractUtil.extractMemberIdFromJwt(request);
+        Member loginMember = memberService.findMember(memberId);
+        String accessToken = jwtExtractUtil.extractAccessTokenFromJwt(request);
+        Long expiration = jwtExtractUtil.getExpiration(accessToken);
+
+        // REST API 요청을 전송하기 위한 준비 구간
+        RestTemplate restTemplate = new RestTemplate(); // Http 요청을 보내기 위한 템플릿 클래스
+        HttpHeaders userHttpHeaders = new HttpHeaders(); // Http 요청을 위한 Headers
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>(); // Http 요청을 위한 parameters를 설정해주기 위한 클래스
+        HttpEntity<MultiValueMap<String, String>> naverLogoutRequest = new HttpEntity<>(params, userHttpHeaders); // http 요청을 위한 엔티티 클래스 (Header와 Parans를 담아줌)
+
+        userHttpHeaders.add("Authorization", "Bearer " + loginMember.getOauthAccessToken());
+        userHttpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+        params.add("target_id_type", "user_id");
+        params.add("target_id", loginMember.getOauthId().toString());  // 여기서 nullpointer발생
+
+        System.out.println("null?");
+
+        // Naver인증센터에 REST API 요청
+        try {
+            ResponseEntity<String> LogoutResponse = restTemplate.exchange(
+                    "http://nid.naver.com/nidlogin.logout",
+                    HttpMethod.POST,
+                    naverLogoutRequest,
+                    String.class
+            );
+            System.out.println(LogoutResponse);
+
+            memberService.verifyMemberFromRedis(memberId, accessToken, expiration);  // 자체 서비스 로그아웃 로직
+
+        } catch (Exception e) { throw new BusinessLogicException(ExceptionCode.NOT_FOUND); }
 
         return new ResponseEntity<>("Success Logout: User", HttpStatus.OK);
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/entity/Member.java
@@ -36,7 +36,7 @@ public class Member extends BaseTimeEntity {
     @Embedded
     private Photo profile;
 
-    private Long oauthId;
+    private String oauthId;
 
     private String oauthAccessToken;
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/member/service/MemberService.java
@@ -172,7 +172,7 @@ public class MemberService {
                     .memberId(kakaoProfile.getId())
                     .nickname(new Name("Mock"+ kakaoProfile.getId()))
                     .password(passwordEncoder.encode(getInitialKey())) // yml을 통해 시스템 변수 default값 설정해둠
-                    .oauthId(kakaoProfile.getId())
+                    .oauthId(String.valueOf(kakaoProfile.getId()))
                     .oauthAccessToken(kakaoAccessToken)
                     .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
                     .build();
@@ -261,11 +261,10 @@ public class MemberService {
         else optMember = memberRepository.findByEmail(naverProfile.getResponse().getEmail());
 
         if(optMember.isEmpty()) {
-            Member member = Member.builder()
-                    .memberId(Long.valueOf(naverProfile.getResponse().getId()))
+            Member member = Member.builder()  // 네이버의 경우 Id값이 임의의 문자열이므로, 서비스에선 자체 생성하는 방식으로 사용
                     .nickname(new Name("Mock"+ naverProfile.getResponse().getId()))
                     .password(passwordEncoder.encode(getInitialKey())) // yml을 통해 시스템 변수 default값 설정해둠
-                    .oauthId(Long.valueOf(naverProfile.getResponse().getId()))
+                    .oauthId(naverProfile.getResponse().getId())
                     .oauthAccessToken(naverAccessToken)
                     .memberStatus(Member.MemberStatus.MEMBER_ACTIVE)
                     .build();


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [x] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: feat#182


## 무엇이 추가 되었나요?

- 기존 OAuth 2.0 로그인시, Member 객체에 저장되던 OAuthId 필드의 타입을 변경했습니다. 제공사에 따라 숫자 외에도 문자열로 된 식별자를 사용하는 경우가 발생하여 변경했습니다.
- Naver 로그아웃 API를 구현했습니다. 

## 기타 정보
- 네이버에서 제공하는 요청 URL 가이드가 따로 없었기에 로그아웃이 되도록 하는 별도의 요청 URL을 사용했습니다. 이에따라 터미널 로그에 네이버 로그아웃을 표시하는 HTML이 발생합니다만 별다른 조치를 하지 않으셔도 로그아웃 됩니다.
- 네이버의 경우, 카카오와 다르게 식별자가 문자열로 사용됩니다.
- OAuth 2.0을 포함한 로그인 메소드는 모두 Redis 서버를 함께 가동해야 정상적으로 사용이 가능합니다.