### PR TITLE
[BE] Naver 로그인 API Service 계층 분리 리팩토링

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -56,6 +56,7 @@ public class NaverOauthController {
         String url = naverService.createNaverURL();
 
         return new ResponseEntity<>(url, HttpStatus.OK); // 프론트 브라우저로 보내는 주소
+        // Push 확인
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -56,7 +56,6 @@ public class NaverOauthController {
         String url = naverService.createNaverURL();
 
         return new ResponseEntity<>(url, HttpStatus.OK); // 프론트 브라우저로 보내는 주소
-        // Push 확인
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -35,14 +35,7 @@ public class NaverOauthController {
 
     private final NaverService naverService;
     private final MemberService memberService;
-    private final JwtTokenizer jwtTokenizer;
     private final JwtExtractUtil jwtExtractUtil;
-    @Getter
-    @Value("${oauth.naver.clientId}")
-    private String naverClientId;
-    @Getter
-    @Value("${oauth.naver.clientSecret}")
-    private String naverClientSecret;
 
     /**
      * 프론트에 Redirect URI를 제공하기 위한 메소드
@@ -62,92 +55,15 @@ public class NaverOauthController {
     /**
      * 실제 로그인 로직을 수행할 메소드
      *
-     * @return
+     * 비즈니스 로직 성공 : @return "Success Login: User"
+     * 비즈니스 로직 실패 : @return "Fail Login: User"
      */
     @GetMapping("/callback")
     public String naverLogin(@RequestParam("code") String code, @RequestParam("state") String state, HttpServletResponse response) throws JsonProcessingException {
-        // 네이버 로그인 Token 발급 API 요청을 위한 header/parameters 설정 부분
-        RestTemplate token_rt = new RestTemplate(); // REST API 요청용 Template
+        naverService.loginNaver(code, state, response);
 
-        HttpHeaders naverTokenRequestHeadres = new HttpHeaders();  // Http 요청을 위한 헤더 생성
-        naverTokenRequestHeadres.add("Content-type", "application/x-www-form-urlencoded"); // application/json 했다가 grant_type missing 오류남 (출력포맷만 json이라는 거엿음)
-
-        // 파라미터들을 담아주기위한 맵 (파라미터용이기 때문에, 따로 앞에 ?나 &나 =같은 부호를 입력해주지 않아도 됨. 오히려 넣으면 인식못함)
-        // 네이버 가이드에서 요청하는 파라미터들 (Developers 참고)
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", getNaverClientId());
-        params.add("client_secret", getNaverClientSecret());
-        params.add("code", code);
-        params.add("state", state);
-
-        HttpEntity<MultiValueMap<String, String>> naverTokenRequest =
-                new HttpEntity<>(params, naverTokenRequestHeadres);
-
-        // 서비스 서버에서 네이버 인증 서버로 요청 전송(POST 또는 GET이라고 공식문서에 있음), 응답은 Json으로 제공됨
-        ResponseEntity<String> oauthTokenResponse = token_rt.exchange(
-                "https://nid.naver.com/oauth2.0/token",
-                HttpMethod.POST,
-                naverTokenRequest,
-                String.class
-        );
-
-        // body로 access_token, refresh_token, token_type:bearer, expires_in:3600 온 상태
-        System.out.println(oauthTokenResponse);
-
-        // oauthTokenResponse로 받은 토큰정보 객체화
-        ObjectMapper token_om = new ObjectMapper();
-        NaverTokenVo naverToken = null;
-        try {
-            naverToken = token_om.readValue(oauthTokenResponse.getBody(), NaverTokenVo.class);
-        } catch (JsonMappingException je) {
-            je.printStackTrace();
-        }
-
-        // 토큰을 이용해 정보를 받아올 API 요청을 보낼 로직 작성하기
-        RestTemplate profile_rt = new RestTemplate();
-        HttpHeaders userDetailReqHeaders = new HttpHeaders();
-        userDetailReqHeaders.add("Authorization", "Bearer " + naverToken.getAccess_token());
-        userDetailReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=UTF-8");
-        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(userDetailReqHeaders);
-
-        // 서비스서버 - 네이버 인증서버 : 유저 정보 받아오는 API 요청
-        ResponseEntity<String> userDetailResponse = profile_rt.exchange(
-                "https://openapi.naver.com/v1/nid/me",
-                HttpMethod.POST,
-                naverProfileRequest,
-                String.class
-        );
-
-        // 요청 응답 확인
-        System.out.println(userDetailResponse);
-
-        // 네이버로부터 받은 정보를 객체화
-        // *이때, 공식문서에는 응답 파라미터에 mobile 밖에없지만, 국제전화 표기로 된 mobile_e164도 같이 옴. 따라서 NaverProfileVo에 mobile_e164 필드도 있어야 정상적으로 객체가 생성됨
-        ObjectMapper profile_om = new ObjectMapper();
-        NaverProfileVo naverProfile = null;
-        try {
-            naverProfile = profile_om.readValue(userDetailResponse.getBody(), NaverProfileVo.class);
-        } catch (JsonMappingException je) {
-            je.printStackTrace();
-        }
-
-        // 받아온 정보로 서비스 로직에 적용하기
-        Member naverMember = memberService.createNaverMember(naverProfile, naverToken.getAccess_token());
-
-        // 시큐리티 영역
-        // Authentication 을 Security Context Holder 에 저장
-        Authentication authentication = new UsernamePasswordAuthenticationToken(naverMember.getEmail(), naverMember.getPassword());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
-        String accessToken = jwtTokenizer.delegateAccessToken(naverMember);
-        String refreshToken = jwtTokenizer.delegateRefreshToken(naverMember);
-        response.setHeader("Authorization", "Bearer " + accessToken);
-        response.setHeader("RefreshToken", refreshToken);
-
-        System.out.println(accessToken);
-        return "Success Login: User";
+        /* Header가 아닌 Redis 서버에 잘 저장이 되었는지 확인하기 */
+        return response.getHeader("Authorization") == null ? "Fail Login: User" :  "Success Login: User";
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
@@ -1,11 +1,27 @@
 package TeamBigDipper.UYouBooDan.global.oauth2.naver;
 
+import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
+import TeamBigDipper.UYouBooDan.member.entity.Member;
 import TeamBigDipper.UYouBooDan.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
 
+import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
 import java.net.URLEncoder;
@@ -23,6 +39,7 @@ public class NaverService {
     @Value("${oauth.naver.clientSecret}")
     private String naverClientSecret;
     private final MemberService memberService;
+    private final JwtTokenizer jwtTokenizer;
 
     public String createNaverURL () throws UnsupportedEncodingException {
         StringBuffer url = new StringBuffer();
@@ -37,7 +54,98 @@ public class NaverService {
         url.append("&state=" + state);
         url.append("&redirect_uri=" + redirectURI);
 
+        /* 로그인 중 선택 권한 허용 URL로 redirect 문제 해결하기
+           로그인 시도시, "현재 UYouBooDan은 개발 중 상태입니다. 개발 중 상태에서는 등록된 아이디만 로그인할 수 있습니다." 화면으로 가버림.
+           아래와 같은 URL로 리다이렉트 되도록 유도하는 해결책 찾기
+           : https://nid.naver.com/oauth2.0/authorize?client_id=avgLtiDUfWMFfHpplTZh&redirect_uri=https://developers.naver.com/proxyapi/forum/auth/oAuth2&response_type=code&state=RZ760w
+         */
+
         return url.toString();
     }
 
+    public void loginNaver (String code, String state, HttpServletResponse response) throws JsonProcessingException {
+        // 네이버 로그인 Token 발급 API 요청을 위한 header/parameters 설정 부분
+        RestTemplate token_rt = new RestTemplate(); // REST API 요청용 Template
+
+        HttpHeaders naverTokenRequestHeadres = new HttpHeaders();  // Http 요청을 위한 헤더 생성
+        naverTokenRequestHeadres.add("Content-type", "application/x-www-form-urlencoded"); // application/json 했다가 grant_type missing 오류남 (출력포맷만 json이라는 거엿음)
+
+        // 파라미터들을 담아주기위한 맵 (파라미터용이기 때문에, 따로 앞에 ?나 &나 =같은 부호를 입력해주지 않아도 됨. 오히려 넣으면 인식못함)
+        // 네이버 가이드에서 요청하는 파라미터들 (Developers 참고)
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", getNaverClientId());
+        params.add("client_secret", getNaverClientSecret());
+        params.add("code", code);
+        params.add("state", state);
+
+        HttpEntity<MultiValueMap<String, String>> naverTokenRequest =
+                new HttpEntity<>(params, naverTokenRequestHeadres);
+
+        // 서비스 서버에서 네이버 인증 서버로 요청 전송(POST 또는 GET이라고 공식문서에 있음), 응답은 Json으로 제공됨
+        ResponseEntity<String> oauthTokenResponse = token_rt.exchange(
+                "https://nid.naver.com/oauth2.0/token",
+                HttpMethod.POST,
+                naverTokenRequest,
+                String.class
+        );
+
+        // body로 access_token, refresh_token, token_type:bearer, expires_in:3600 온 상태
+        System.out.println(oauthTokenResponse);
+
+        // oauthTokenResponse로 받은 토큰정보 객체화
+        ObjectMapper token_om = new ObjectMapper();
+        NaverTokenVo naverToken = null;
+        try {
+            naverToken = token_om.readValue(oauthTokenResponse.getBody(), NaverTokenVo.class);
+        } catch (JsonMappingException je) {
+            je.printStackTrace();
+        }
+
+        // 토큰을 이용해 정보를 받아올 API 요청을 보낼 로직 작성하기
+        RestTemplate profile_rt = new RestTemplate();
+        HttpHeaders userDetailReqHeaders = new HttpHeaders();
+        userDetailReqHeaders.add("Authorization", "Bearer " + naverToken.getAccess_token());
+        userDetailReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(userDetailReqHeaders);
+
+        // 서비스서버 - 네이버 인증서버 : 유저 정보 받아오는 API 요청
+        ResponseEntity<String> userDetailResponse = profile_rt.exchange(
+                "https://openapi.naver.com/v1/nid/me",
+                HttpMethod.POST,
+                naverProfileRequest,
+                String.class
+        );
+
+        // 요청 응답 확인
+        System.out.println(userDetailResponse);
+
+        // 네이버로부터 받은 정보를 객체화
+        // *이때, 공식문서에는 응답 파라미터에 mobile 밖에없지만, 국제전화 표기로 된 mobile_e164도 같이 옴. 따라서 NaverProfileVo에 mobile_e164 필드도 있어야 정상적으로 객체가 생성됨
+        ObjectMapper profile_om = new ObjectMapper();
+        NaverProfileVo naverProfile = null;
+        try {
+            naverProfile = profile_om.readValue(userDetailResponse.getBody(), NaverProfileVo.class);
+        } catch (JsonMappingException je) {
+            je.printStackTrace();
+        }
+
+        // 받아온 정보로 서비스 로직에 적용하기
+        Member naverMember = memberService.createNaverMember(naverProfile, naverToken.getAccess_token());
+
+        // 시큐리티 영역
+        // Authentication 을 Security Context Holder 에 저장
+        Authentication authentication = new UsernamePasswordAuthenticationToken(naverMember.getEmail(), naverMember.getPassword());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
+        String accessToken = jwtTokenizer.delegateAccessToken(naverMember);
+        String refreshToken = jwtTokenizer.delegateRefreshToken(naverMember);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("RefreshToken", refreshToken);
+
+        /* RefreshToken을 Redis에 넣어주는 과정 필요  */
+
+        System.out.println(accessToken);
+    }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
@@ -1,0 +1,43 @@
+package TeamBigDipper.UYouBooDan.global.oauth2.naver;
+
+import TeamBigDipper.UYouBooDan.member.service.MemberService;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+import java.math.BigInteger;
+import java.net.URLEncoder;
+import java.security.SecureRandom;
+
+@Service
+@RequiredArgsConstructor
+public class NaverService {
+
+    @Getter
+    @Value("${oauth.naver.clientId}")
+    private String naverClientId;
+
+    @Getter
+    @Value("${oauth.naver.clientSecret}")
+    private String naverClientSecret;
+    private final MemberService memberService;
+
+    public String createNaverURL () throws UnsupportedEncodingException {
+        StringBuffer url = new StringBuffer();
+
+        // 카카오 API 명세에 맞춰서 작성
+        String redirectURI = URLEncoder.encode("http://www.localhost:8080/naver/callback", "UTF-8"); // redirectURI 설정 부분
+        SecureRandom random = new SecureRandom();
+        String state = new BigInteger(130, random).toString();
+
+        url.append("https://nid.naver.com/oauth2.0/authorize?response_type=code");
+        url.append("&client_id=" + getNaverClientId());
+        url.append("&state=" + state);
+        url.append("&redirect_uri=" + redirectURI);
+
+        return url.toString();
+    }
+
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
@@ -9,6 +9,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
@@ -40,6 +42,7 @@ public class NaverService {
     private String naverClientSecret;
     private final MemberService memberService;
     private final JwtTokenizer jwtTokenizer;
+    private final RedisTemplate redisTemplate;
 
     public String createNaverURL () throws UnsupportedEncodingException {
         StringBuffer url = new StringBuffer();
@@ -144,7 +147,9 @@ public class NaverService {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("RefreshToken", refreshToken);
 
-        /* RefreshToken을 Redis에 넣어주는 과정 필요  */
+        // RefreshToken을 Redis에 넣어주는 과정
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("RTKey"+naverMember.getMemberId(), refreshToken);
 
         System.out.println(accessToken);
     }


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #183 


## 무엇이 추가 되었나요?

- Naver 로그인 API의 Controller에 있던 비즈니스 로직을 Service계층으로 옮겼습니다.
- Naver 로그인 로직 중, Refresh Token이  Redis 서버에 저장 되도록 코드를 추가했습니다.

## 기타 정보
- 직전 PR에서 설명드리지 못한 yml설정 방법을 공유합니다.
- Naver 로그인 시, 아래의 설정을 application-local.yml에 추가하셔야 정상 동작합니다.
- 
oauth:
  ...
  naver:
    clientId: {네이버로부터_발급받은_클라이언트ID값}
    clientSecret: {네이버로부터_발급받은_서비스_시크릿값}
