### PR TITLE
[BE] 카카오 로그인 Service계층 분리

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -30,18 +30,9 @@ import java.io.UnsupportedEncodingException;
 @RequestMapping("/kakao")
 public class KakaoOauthController {
 
-    @Getter
-    @Value("${oauth.kakao.appKey.restApiKey}")
-    private String kakaoAppKey;
-    @Getter
-    @Value("${oauth.kakao.clientId}")
-    private String kakaoClientId;
-    private final MemberService memberService;
-    private final JwtTokenizer jwtTokenizer;
-
-    private final JwtExtractUtil jwtExtractUtil;
     private final KakaoService kakaoService;
-
+    private final MemberService memberService;
+    private final JwtExtractUtil jwtExtractUtil;
 
     /**
      * 프론트 요청 API : 인증 code 받기용
@@ -63,68 +54,9 @@ public class KakaoOauthController {
      */
     @GetMapping("/callback")
     public String kakaoLogin(@RequestParam("code") String code, HttpServletResponse response) throws JsonProcessingException {
-        RestTemplate restTemplate = new RestTemplate();
-        HttpHeaders kakaoTokenReqHeaders = new HttpHeaders(); // springFramework.http 라이브러리
-        kakaoTokenReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8"); // json이 아니다 (카카오 REST API 참고)
+        kakaoService.loginKakao(code, response);
 
-        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
-        params.add("grant_type", "authorization_code");
-        params.add("client_id", getKakaoAppKey());
-        params.add("redirect_url", "http://localhost:8080"); // redirect url 확인하기
-        params.add("code", code);
-
-        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
-                new HttpEntity<>(params, kakaoTokenReqHeaders);
-
-        // fetching for token
-        ResponseEntity<String> oauthTokenResponse = restTemplate.exchange(
-                "https://kauth.kakao.com/oauth/token",
-                HttpMethod.POST,
-                kakaoTokenRequest,
-                String.class
-        );
-
-        // kakao token converting process
-        ObjectMapper objectMapper = new ObjectMapper();
-        KakaoTokenVo kakaoToken = null;
-        try { kakaoToken = objectMapper.readValue(oauthTokenResponse.getBody(), KakaoTokenVo.class); }
-        catch (JsonMappingException je) { je.printStackTrace(); }
-
-        RestTemplate restTemplate2 = new RestTemplate();
-        HttpHeaders userDetailsReqHeaders = new HttpHeaders();
-        userDetailsReqHeaders.add("Authorization", "Bearer " + kakaoToken.getAccess_token());
-        userDetailsReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=UTF-8");
-        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(userDetailsReqHeaders);
-
-        // fetching for profile data
-        ResponseEntity<String> userDetailsResponse = restTemplate2.exchange(
-                "https://kapi.kakao.com/v2/user/me",
-                HttpMethod.POST,
-                kakaoProfileRequest,
-                String.class
-        );
-
-        // kakao profile converting process
-        ObjectMapper objectMapper2 = new ObjectMapper();
-        KakaoProfileVo kakaoProfile = null;
-        try { kakaoProfile = objectMapper2.readValue(userDetailsResponse.getBody(), KakaoProfileVo.class); }
-        catch (JsonMappingException je) { je.printStackTrace(); }
-
-        // 서비스 회원 등록 위임
-        Member kakaoMember = memberService.createKakaoMember(kakaoProfile, kakaoToken.getAccess_token());
-
-        // 시큐리티 영역
-        // Authentication 을 Security Context Holder 에 저장
-        Authentication authentication = new UsernamePasswordAuthenticationToken(kakaoMember.getEmail(), kakaoMember.getPassword()); // password 확인
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-
-        // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
-        String accessToken = jwtTokenizer.delegateAccessToken(kakaoMember);
-        String refreshToken = jwtTokenizer.delegateRefreshToken(kakaoMember);
-        response.setHeader("Authorization", "Bearer " + accessToken);
-        response.setHeader("RefreshToken", refreshToken);
-
-        return "Success Login: User";
+        return response.getHeader("Authorization") == null ? "Fail Login: User" :  "Success Login: User";
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -23,6 +23,7 @@ import org.springframework.web.client.RestTemplate;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
 
 @RequiredArgsConstructor
 @RestController
@@ -39,6 +40,7 @@ public class KakaoOauthController {
     private final JwtTokenizer jwtTokenizer;
 
     private final JwtExtractUtil jwtExtractUtil;
+    private final KakaoService kakaoService;
 
 
     /**
@@ -46,14 +48,10 @@ public class KakaoOauthController {
      * @return redirect url for kakao Authorization
      */
     @GetMapping("/oauth")
-    public ResponseEntity<?> kakaoConnect() {
-        StringBuffer url = new StringBuffer();
-        url.append("https://kauth.kakao.com/oauth/authorize?");
-        url.append("client_id=" + getKakaoAppKey()); // App Key
-        url.append("&redirect_uri=http://www.localhost:3000/auth/kakaoredirect"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
-        url.append("&response_type=code");
+    public ResponseEntity<?> kakaoConnect() throws UnsupportedEncodingException {
+        String url = kakaoService.createKakaoURL();
 
-        return new ResponseEntity<>(url.toString(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)
+        return new ResponseEntity<>(url, HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -1,0 +1,34 @@
+package TeamBigDipper.UYouBooDan.global.oauth2.kakao;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.UnsupportedEncodingException;
+
+@Service
+@RequiredArgsConstructor
+public class KakaoService {
+
+    @Getter
+    @Value("${oauth.kakao.appKey.restApiKey}")
+    private String kakaoAppKey;
+    @Getter
+    @Value("${oauth.kakao.clientId}")
+    private String kakaoClientId;
+
+    /**
+     * @return 카카오 인증서버로 클라이언트가 요청을 보내기위한 Redirect Url
+     */
+    public String createKakaoURL () throws UnsupportedEncodingException {
+        StringBuffer url = new StringBuffer();
+        url.append("https://kauth.kakao.com/oauth/authorize?");
+        url.append("client_id=" + getKakaoAppKey()); // App Key
+        url.append("&redirect_uri=http://www.localhost:3000/auth/kakaoredirect"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
+        url.append("&response_type=code");
+
+        return url.toString();
+    }
+
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -120,6 +120,10 @@ public class KakaoService {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("RefreshToken", refreshToken);
 
+        // RefreshToken을 Redis에 넣어주는 과정
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("RTKey"+kakaoMember.getMemberId(), refreshToken);
+
         System.out.println(accessToken);
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -1,10 +1,28 @@
 package TeamBigDipper.UYouBooDan.global.oauth2.kakao;
 
+import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
+import TeamBigDipper.UYouBooDan.member.entity.Member;
+import TeamBigDipper.UYouBooDan.member.service.MemberService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
-
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestTemplate;
+import javax.servlet.http.HttpServletResponse;
 import java.io.UnsupportedEncodingException;
 
 @Service
@@ -17,6 +35,9 @@ public class KakaoService {
     @Getter
     @Value("${oauth.kakao.clientId}")
     private String kakaoClientId;
+    private final MemberService memberService;
+    private final JwtTokenizer jwtTokenizer;
+    private final RedisTemplate redisTemplate;
 
     /**
      * @return 카카오 인증서버로 클라이언트가 요청을 보내기위한 Redirect Url
@@ -31,4 +52,74 @@ public class KakaoService {
         return url.toString();
     }
 
+    /**
+     *
+     * @param code : 카카오로부터 받아 카카오 인증센터에 검증요청을 하기 위한 code
+     * @param response
+     * @throws JsonProcessingException
+     */
+    public void loginKakao (String code, HttpServletResponse response) throws JsonProcessingException {
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders kakaoTokenReqHeaders = new HttpHeaders(); // springFramework.http 라이브러리
+        kakaoTokenReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8"); // json이 아니다 (카카오 REST API 참고)
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", getKakaoAppKey());
+        params.add("redirect_url", "http://localhost:8080"); // redirect url 확인하기
+        params.add("code", code);
+
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest =
+                new HttpEntity<>(params, kakaoTokenReqHeaders);
+
+        // fetching for token
+        ResponseEntity<String> oauthTokenResponse = restTemplate.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+
+        // kakao token converting process
+        ObjectMapper objectMapper = new ObjectMapper();
+        KakaoTokenVo kakaoToken = null;
+        try { kakaoToken = objectMapper.readValue(oauthTokenResponse.getBody(), KakaoTokenVo.class); }
+        catch (JsonMappingException je) { je.printStackTrace(); }
+
+        RestTemplate restTemplate2 = new RestTemplate();
+        HttpHeaders userDetailsReqHeaders = new HttpHeaders();
+        userDetailsReqHeaders.add("Authorization", "Bearer " + kakaoToken.getAccess_token());
+        userDetailsReqHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=UTF-8");
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(userDetailsReqHeaders);
+
+        // fetching for profile data
+        ResponseEntity<String> userDetailsResponse = restTemplate2.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoProfileRequest,
+                String.class
+        );
+
+        // kakao profile converting process
+        ObjectMapper objectMapper2 = new ObjectMapper();
+        KakaoProfileVo kakaoProfile = null;
+        try { kakaoProfile = objectMapper2.readValue(userDetailsResponse.getBody(), KakaoProfileVo.class); }
+        catch (JsonMappingException je) { je.printStackTrace(); }
+
+        // 서비스 회원 등록 위임
+        Member kakaoMember = memberService.createKakaoMember(kakaoProfile, kakaoToken.getAccess_token());
+
+        // 시큐리티 영역
+        // Authentication 을 Security Context Holder 에 저장
+        Authentication authentication = new UsernamePasswordAuthenticationToken(kakaoMember.getEmail(), kakaoMember.getPassword()); // password 확인
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
+        String accessToken = jwtTokenizer.delegateAccessToken(kakaoMember);
+        String refreshToken = jwtTokenizer.delegateRefreshToken(kakaoMember);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("RefreshToken", refreshToken);
+
+        System.out.println(accessToken);
+    }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
@@ -66,6 +66,13 @@ public class NaverService {
         return url.toString();
     }
 
+    /**
+     *
+     * @param code : 네이버로부터 받아 네이버 인증센터에 검증요청을 하기 위한 code
+     * @param state
+     * @param response
+     * @throws JsonProcessingException
+     */
     public void loginNaver (String code, String state, HttpServletResponse response) throws JsonProcessingException {
         // 네이버 로그인 Token 발급 API 요청을 위한 header/parameters 설정 부분
         RestTemplate token_rt = new RestTemplate(); // REST API 요청용 Template


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: #188


## 무엇이 추가 되었나요?

- 카카오 로그인 리다이렉트 URL API (kakaoConnect 핸들러 메소드) 내 비즈니스 로직을 Service 클래스로 분리했습니다.
- 카카오 로그인 API (kakaoLogin 핸들러 메소드) 내 비즈니스 로직을 Service 클래스로 분리했습니다.
- 카카오 로그인 비즈니스 로직 중 Redis 서버에 Refresh Token을 저장하는 로직을 수정했습니다.

## 기타 정보
- 로그이웃 API의 리팩토링 작업은 이후 추가로 진행하겠습니다.
- 비즈니스 로직 내 통합적으로 사용할 수 있는 로직을 따로 엔티티 클래스 내에 메소드로 리팩토링하는 작업은 다음 PR에서 추가로 진행하겠습니다.

-