### PR TITLE
[BE] Google 로그인 API 리팩토링 및 소셜 로그인 내 Security Role 부여 공통화 리팩토링

### DIFF
--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleOauthController.java
@@ -58,7 +58,7 @@ public class GoogleOauthController {
     public String redirectGoogleLogin(@RequestParam("code") String code, HttpServletResponse response) {
         googleService.loginGoogle(code, response);
 
-        return response.getHeader("Authorization") == null ? "Fail Login: User" :  "Success Login: User";
+        return response.getHeader("Authorization") == null ? "Fail Login: User" : "Success Login: User";
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleOauthController.java
@@ -26,11 +26,13 @@ import org.springframework.web.util.UriComponentsBuilder;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.io.UnsupportedEncodingException;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/google")
 public class GoogleOauthController {
+
     @Getter
     @Value("${oauth.google.clientId}")
     private String googleClientId;
@@ -42,7 +44,7 @@ public class GoogleOauthController {
     private String googleRedirectUrl;
     @Value("${oauth.google.scope}")
     private String scopes;
-
+    private final GoogleService googleService;
     private final MemberService memberService;
     private final JwtTokenizer jwtTokenizer;
     private final JwtExtractUtil jwtExtractUtil;
@@ -53,14 +55,8 @@ public class GoogleOauthController {
      */
     @GetMapping("/oauth")
     public ResponseEntity<?> googleConnect() {
-        StringBuffer url = new StringBuffer();
-        url.append("https://accounts.google.com/o/oauth2/v2/auth?");
-        url.append("client_id=" + getGoogleClientId());
-        url.append("&redirect_uri=" + getGoogleRedirectUrl());
-        url.append("&response_type=code");
-        url.append("&scope="+ getScopeUrl());
 
-        return new ResponseEntity<>(url.toString(), HttpStatus.OK);
+        return new ResponseEntity<>(googleService.createGoogleURL(), HttpStatus.OK);
     }
 
 
@@ -169,14 +165,5 @@ public class GoogleOauthController {
 
 
         return new ResponseEntity<>("Success Logout: User", HttpStatus.OK);
-    }
-
-
-    /**
-     * scope 설정용 get 메소드
-     * @return scopes
-     */
-    private String getScopeUrl() {
-        return scopes.replaceAll(",", "%20");
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
@@ -135,6 +135,10 @@ public class GoogleService {
         response.setHeader("Authorization", "Bearer " + accessToken);
         response.setHeader("RefreshToken", refreshToken);
 
+        // RefreshToken을 Redis에 넣어주는 과정
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        valueOperations.set("RTKey"+googleMember.getMemberId(), refreshToken);
+
         System.out.println(accessToken);
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
@@ -13,9 +13,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.http.*;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -126,11 +123,6 @@ public class GoogleService {
         // 서비스 회원 등록 위임
         googleProfile = userDetailsResponse.getBody();
         Member googleMember = memberService.createGoogleMember(googleProfile, loginResponse.getAccessToken());
-
-        // 시큐리티 영역
-        // Authentication 을 Security Context Holder 에 저장
-        Authentication authentication = new UsernamePasswordAuthenticationToken(googleMember.getEmail(), googleMember.getPassword()); // password 확인
-        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
         String accessToken = jwtTokenizer.delegateAccessToken(googleMember);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
@@ -1,0 +1,42 @@
+package TeamBigDipper.UYouBooDan.global.oauth2.google;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class GoogleService {
+
+    @Getter
+    @Value("${oauth.google.clientId}")
+    private String googleClientId;
+    @Getter
+    @Value("${oauth.google.clientSecret}")
+    private String googleClientSecret;
+    @Getter
+    @Value("${oauth.google.redirectUrl}")
+    private String googleRedirectUrl;
+    @Value("${oauth.google.scope}")
+    private String scopes;
+
+    public String createGoogleURL () {
+        StringBuffer url = new StringBuffer();
+        url.append("https://accounts.google.com/o/oauth2/v2/auth?");
+        url.append("client_id=" + getGoogleClientId());
+        url.append("&redirect_uri=" + getGoogleRedirectUrl());
+        url.append("&response_type=code");
+        url.append("&scope="+ getScopeUrl());
+
+        return url.toString();
+    }
+
+    /**
+     * scope 설정용 get 메소드
+     * @return scopes
+     */
+    private String getScopeUrl() {
+        return scopes.replaceAll(",", "%20");
+    }
+}

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
@@ -1,9 +1,26 @@
 package TeamBigDipper.UYouBooDan.global.oauth2.google;
 
+import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
+import TeamBigDipper.UYouBooDan.member.entity.Member;
+import TeamBigDipper.UYouBooDan.member.service.MemberService;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.PropertyNamingStrategy;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.http.*;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.http.HttpServletResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -20,6 +37,10 @@ public class GoogleService {
     private String googleRedirectUrl;
     @Value("${oauth.google.scope}")
     private String scopes;
+    private final JwtTokenizer jwtTokenizer;
+    private final MemberService memberService;
+    private final RedisTemplate redisTemplate;
+
 
     public String createGoogleURL () {
         StringBuffer url = new StringBuffer();
@@ -38,5 +59,82 @@ public class GoogleService {
      */
     private String getScopeUrl() {
         return scopes.replaceAll(",", "%20");
+    }
+
+    public void loginGoogle (String code, HttpServletResponse response) {
+
+        // Http 통신을 위한 RestTemplate 활용
+        RestTemplate restTemplate = new RestTemplate();
+        GoogleLoginReqVo request = GoogleLoginReqVo.builder()
+                .clientId(getGoogleClientId())
+                .clientSecret(getGoogleClientSecret())
+                .code(code)
+                .redirectUri(getGoogleRedirectUrl())
+                .grantType("authorization_code")
+                .build();
+
+        // try ~ catch 문을 통해 성공했을 경우 값을 전달받기위한 엔티티 클래스
+        ResponseEntity<GoogleLoginDto> userDetailsResponse = null;
+        // try ~ catch 문을 통해 성공했을 경우 토큰을 전달받기위 DTO 클래스
+        ResponseEntity<String> oauthTokenResponse;
+        // try ~ catch 문을 통해 성공했을 경우 로그인 Response를 전달받기 위한 VO
+        GoogleLoginResVo loginResponse = null;
+        // try ~ catch 문을 통해 성공했을 경우 값을 전달받기위 DTO 클래스
+        GoogleLoginDto googleProfile;
+
+        // 구글로 토큰 발급 및 계정정보 요청
+        try {
+            // Http Header 설정
+            HttpHeaders headers  = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            HttpEntity<GoogleLoginReqVo> googleTokenRequest = new HttpEntity<>(request, headers);
+
+            // fetching for token
+//            oauthTokenResponse = restTemplate.postForEntity("https://oauth2.googleapis.com" + "/token", googleTokenRequest, String.class); // legacy 코드
+            oauthTokenResponse = restTemplate.exchange(
+                    "https://oauth2.googleapis.com" + "/token",
+                    HttpMethod.POST,
+                    googleTokenRequest,
+                    String.class
+            );
+
+            // Google token converting process
+            ObjectMapper objectMapper = new ObjectMapper();
+            objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+            objectMapper.setSerializationInclusion(JsonInclude.Include.NON_NULL); // NULL이 아닌 값만 응답 받기
+            loginResponse = objectMapper.readValue(oauthTokenResponse.getBody(), new TypeReference<>() {});
+
+            String jwtToken = loginResponse.getIdToken();
+            String requestUrl = UriComponentsBuilder.fromHttpUrl("https://oauth2.googleapis.com/tokeninfo").queryParam("id_token", jwtToken).toUriString();
+
+            // fetching for profile data
+            String resultJson = restTemplate.getForObject(requestUrl, String.class);
+
+            // Google profile converting process
+            if(resultJson != null) {
+                GoogleLoginDto loginDto = objectMapper.readValue(resultJson, new TypeReference<>() {});
+                userDetailsResponse = ResponseEntity.ok().body(loginDto);
+            } else {
+                throw new Exception("Google OAuth failed");
+            }
+
+        } catch (Exception e) { e.printStackTrace(); }
+
+        // 서비스 회원 등록 위임
+        googleProfile = userDetailsResponse.getBody();
+        Member googleMember = memberService.createGoogleMember(googleProfile, loginResponse.getAccessToken());
+
+        // 시큐리티 영역
+        // Authentication 을 Security Context Holder 에 저장
+        Authentication authentication = new UsernamePasswordAuthenticationToken(googleMember.getEmail(), googleMember.getPassword()); // password 확인
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
+        String accessToken = jwtTokenizer.delegateAccessToken(googleMember);
+        String refreshToken = jwtTokenizer.delegateRefreshToken(googleMember);
+        response.setHeader("Authorization", "Bearer " + accessToken);
+        response.setHeader("RefreshToken", refreshToken);
+
+        System.out.println(accessToken);
     }
 }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/google/GoogleService.java
@@ -35,6 +35,9 @@ public class GoogleService {
     @Getter
     @Value("${oauth.google.redirectUrl}")
     private String googleRedirectUrl;
+    @Getter
+    @Value("${jwt.refresh-token-prefix}")
+    private String refreshPrefix;
     @Value("${oauth.google.scope}")
     private String scopes;
     private final JwtTokenizer jwtTokenizer;
@@ -137,7 +140,7 @@ public class GoogleService {
 
         // RefreshToken을 Redis에 넣어주는 과정
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        valueOperations.set("RTKey"+googleMember.getMemberId(), refreshToken);
+        valueOperations.set(getRefreshPrefix()+googleMember.getMemberId(), refreshToken);
 
         System.out.println(accessToken);
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoOauthController.java
@@ -40,9 +40,8 @@ public class KakaoOauthController {
      */
     @GetMapping("/oauth")
     public ResponseEntity<?> kakaoConnect() throws UnsupportedEncodingException {
-        String url = kakaoService.createKakaoURL();
 
-        return new ResponseEntity<>(url, HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)
+        return new ResponseEntity<>(kakaoService.createKakaoURL(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소(프론트에서 받아서 리다이렉트 시키면, 인가코드를 받을 수 있다.)
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -42,7 +42,7 @@ public class KakaoService {
     /**
      * @return 카카오 인증서버로 클라이언트가 요청을 보내기위한 Redirect Url
      */
-    public String createKakaoURL () throws UnsupportedEncodingException {
+    public String createKakaoURL () {
         StringBuffer url = new StringBuffer();
         url.append("https://kauth.kakao.com/oauth/authorize?");
         url.append("client_id=" + getKakaoAppKey()); // App Key

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -15,15 +15,11 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 import javax.servlet.http.HttpServletResponse;
-import java.io.UnsupportedEncodingException;
 
 @Service
 @RequiredArgsConstructor
@@ -50,6 +46,7 @@ public class KakaoService {
         url.append("https://kauth.kakao.com/oauth/authorize?");
         url.append("client_id=" + getKakaoAppKey()); // App Key
         url.append("&redirect_uri=http://www.localhost:3000/auth/kakaoredirect"); // 프론트쪽에서 인가 코드를 받을 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
+//        url.append("&redirect_uri=http://www.localhost:8080/kakao/callback"); // 백엔드 로그인 테스트용 리다이렉트 URL(카카오 리다이렉트에 등록 필요)
         url.append("&response_type=code");
 
         return url.toString();
@@ -111,11 +108,6 @@ public class KakaoService {
 
         // 서비스 회원 등록 위임
         Member kakaoMember = memberService.createKakaoMember(kakaoProfile, kakaoToken.getAccess_token());
-
-        // 시큐리티 영역
-        // Authentication 을 Security Context Holder 에 저장
-        Authentication authentication = new UsernamePasswordAuthenticationToken(kakaoMember.getEmail(), kakaoMember.getPassword()); // password 확인
-        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
         String accessToken = jwtTokenizer.delegateAccessToken(kakaoMember);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/kakao/KakaoService.java
@@ -35,6 +35,9 @@ public class KakaoService {
     @Getter
     @Value("${oauth.kakao.clientId}")
     private String kakaoClientId;
+    @Getter
+    @Value("${jwt.refresh-token-prefix}")
+    private String refreshPrefix;
     private final MemberService memberService;
     private final JwtTokenizer jwtTokenizer;
     private final RedisTemplate redisTemplate;
@@ -122,7 +125,7 @@ public class KakaoService {
 
         // RefreshToken을 Redis에 넣어주는 과정
         ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
-        valueOperations.set("RTKey"+kakaoMember.getMemberId(), refreshToken);
+        valueOperations.set(getRefreshPrefix()+kakaoMember.getMemberId(), refreshToken);
 
         System.out.println(accessToken);
     }

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverOauthController.java
@@ -46,9 +46,8 @@ public class NaverOauthController {
      */
     @GetMapping("/oauth")
     public ResponseEntity<?> naverConnect() throws UnsupportedEncodingException {
-        String url = naverService.createNaverURL();
 
-        return new ResponseEntity<>(url, HttpStatus.OK); // 프론트 브라우저로 보내는 주소
+        return new ResponseEntity<>(naverService.createNaverURL(), HttpStatus.OK); // 프론트 브라우저로 보내는 주소
     }
 
 

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/oauth2/naver/NaverService.java
@@ -16,9 +16,6 @@ import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Service;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -147,14 +144,6 @@ public class NaverService {
 
         // 받아온 정보로 서비스 로직에 적용하기
         Member naverMember = memberService.createNaverMember(naverProfile, naverToken.getAccess_token());
-
-        /**
-         * Refactor : 아래의 Authentication 부여 영역과 OAuth 2.0 멤버 Role부여 로직은 JwtVerificationFilter 내 메소드로 통합 이전 할 예정입니다.
-         */
-        // 시큐리티 영역
-        // Authentication 을 Security Context Holder 에 저장
-        Authentication authentication = new UsernamePasswordAuthenticationToken(naverMember.getEmail(), naverMember.getPassword());
-        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         // 자체 JWT 생성 및 HttpServletResponse 의 Header 에 저장 (클라이언트 응답용)
         String accessToken = jwtTokenizer.delegateAccessToken(naverMember);

--- a/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtVerificationFilter.java
+++ b/BE/UYouBooDan/src/main/java/TeamBigDipper/UYouBooDan/global/security/filter/JwtVerificationFilter.java
@@ -2,6 +2,7 @@ package TeamBigDipper.UYouBooDan.global.security.filter;
 
 import TeamBigDipper.UYouBooDan.global.security.jwt.JwtTokenizer;
 import TeamBigDipper.UYouBooDan.global.security.util.CustomAuthorityUtils;
+import TeamBigDipper.UYouBooDan.member.entity.Member;
 import io.jsonwebtoken.ExpiredJwtException;
 import io.jsonwebtoken.security.SignatureException;
 import lombok.RequiredArgsConstructor;
@@ -10,6 +11,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import javax.servlet.FilterChain;
@@ -18,6 +20,7 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.List;
 import java.util.Map;
 
+@Component  // 일부 메소드 사용을 위한 DI를 위해 Bean 등록
 @RequiredArgsConstructor
 public class JwtVerificationFilter extends OncePerRequestFilter {
 
@@ -81,6 +84,16 @@ public class JwtVerificationFilter extends OncePerRequestFilter {
 
         Authentication authentication = new UsernamePasswordAuthenticationToken(username, null, authorityList);
         SecurityContextHolder.getContext().setAuthentication(authentication); // SecurityContextHolder에 인증정보(Context) 업데이트해줌
+    }
+
+    /**
+     * OAuth 2.0 로그인 시, 유저와 역할을 SecurituContextHolder에 넣어주는 메소드 (MemberService 내 호출)
+     * @param member
+     */
+    public void setOauthSecurityContext(Member member) {
+        List<GrantedAuthority> authorityList = customAuthorityUtils.createAuthorities(member.getRoles());
+        Authentication authentication = new UsernamePasswordAuthenticationToken(member.getEmail(), member.getPassword(),authorityList);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
     }
 
 }

--- a/BE/UYouBooDan/src/main/resources/application-real.yml
+++ b/BE/UYouBooDan/src/main/resources/application-real.yml
@@ -46,6 +46,7 @@ jwt:
     secret: ${JWT_SECRET_KEY}
     access-token-expiration-minutes: 30
     refresh-token-expiration-minutes: 1440
+  refresh-token-prefix: RTKey
 oauth:
   kakao:
     appKey:

--- a/BE/UYouBooDan/src/main/resources/application-real.yml
+++ b/BE/UYouBooDan/src/main/resources/application-real.yml
@@ -58,3 +58,6 @@ oauth:
     clientSecret: ${GOOGLE_CLIENT_SECRET}
     scope: profile,email,openid
     redirectUrl: http://localhost:3000/auth/googleredirect
+  naver:
+    clientId: ${NAVER_CLIENT_ID}
+    clientSecret: ${NAVER_CLIENT_SECRET}


### PR DESCRIPTION
## PR Checklist
PR이 다음 요구사항을 만족하는지 확인해주세요.

- [x] 커밋 메시지가 정책을 따르나요?
- [x] 해당 기능이 정상적으로 작동 하나요?


## PR Type
어떤 종류의 PR인가요?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] angular.io application / infrastructure changes
- [ ] Other... Please describe:


## 이슈와 연결하기

Issue Number: 189


## 무엇이 추가 되었나요?

- Google 로그인 API의 서비스 계층 분리
- Google 로그인 API 중 RefreshToken 캐싱 로직 수정
- RefreshToken 서버사이드 캐싱시, Redis에 저장되는 Key값용 접두사의 노출을 없애기 위해 yml파일에 설정하여 호출하는 방식으로 수정
- 소셜 로그인 내  시큐리티 Role 부여 로직을 시큐리티 내 JwtVerificationFilter 내 신규 메소드에 위임하여 공통화

## 기타 정보

- Application.yml 내 수정사항이 있습니다.
-  1. RefreshToken 저장에 필요한 Prefix(접두사)를 보안상 yml파일로 옮겼습니다. (노션에 업데이트 했습니다.)
-  2. 게스트 로그인을 위해 SecurityFiler내에 설정해둔 Id 및 PW도 보안상 다음 리팩토링에서 yml로 이전할 예정입니다.
- 두 부분 모두 AWS 파라미터 스토어에 저장이 필요합니다.